### PR TITLE
Crawl for geom_alt prop updates

### DIFF
--- a/data/421/167/827/421167827.geojson
+++ b/data/421/167/827/421167827.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008744,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98255a54faa9c7c6a0982ab131bf9275",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421167827,
-    "wof:lastmodified":1566708852,
+    "wof:lastmodified":1582381941,
     "wof:name":"Acosta",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/167/829/421167829.geojson
+++ b/data/421/167/829/421167829.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008745,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"689e493f823709c1c3a9f35a67008b55",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421167829,
-    "wof:lastmodified":1566708852,
+    "wof:lastmodified":1582381941,
     "wof:name":"Aserri",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/167/885/421167885.geojson
+++ b/data/421/167/885/421167885.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008746,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee0c07b3f8135695701184a469266353",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421167885,
-    "wof:lastmodified":1566708852,
+    "wof:lastmodified":1582381942,
     "wof:name":"San Ramon",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/169/623/421169623.geojson
+++ b/data/421/169/623/421169623.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008817,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61fec438db2dc608fedb19438a7ef171",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421169623,
-    "wof:lastmodified":1566708855,
+    "wof:lastmodified":1582381942,
     "wof:name":"Tarcoles",
     "wof:parent_id":421204087,
     "wof:placetype":"localadmin",

--- a/data/421/169/971/421169971.geojson
+++ b/data/421/169/971/421169971.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008831,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"636019bee86c355a33c399cf0d26e3d7",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421169971,
-    "wof:lastmodified":1566708854,
+    "wof:lastmodified":1582381942,
     "wof:name":"San Mateo",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/169/973/421169973.geojson
+++ b/data/421/169/973/421169973.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008831,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a37ac453044c2a7a2ef8e532ede9d5e9",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421169973,
-    "wof:lastmodified":1566708855,
+    "wof:lastmodified":1582381942,
     "wof:name":"Los Chiles",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/169/975/421169975.geojson
+++ b/data/421/169/975/421169975.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008831,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c564d552945752b6063e5792cf347bb",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421169975,
-    "wof:lastmodified":1566708855,
+    "wof:lastmodified":1582381942,
     "wof:name":"Montes De Oca",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/169/977/421169977.geojson
+++ b/data/421/169/977/421169977.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008831,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9af9436eb9e95318b0c004b0822cbd53",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421169977,
-    "wof:lastmodified":1566708854,
+    "wof:lastmodified":1582381942,
     "wof:name":"Tarrazu",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/170/047/421170047.geojson
+++ b/data/421/170/047/421170047.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80cc6244a0cde4e0f8cb628078466a78",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421170047,
-    "wof:lastmodified":1566708888,
+    "wof:lastmodified":1582381951,
     "wof:name":"Jimenez",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/170/049/421170049.geojson
+++ b/data/421/170/049/421170049.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27f6bcb5e077d43835d38bb5bd059515",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421170049,
-    "wof:lastmodified":1566708888,
+    "wof:lastmodified":1582381950,
     "wof:name":"La Cruz",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/170/051/421170051.geojson
+++ b/data/421/170/051/421170051.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1aebe612f0b1c5f2ff996776f4d20c9a",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421170051,
-    "wof:lastmodified":1566708890,
+    "wof:lastmodified":1582381951,
     "wof:name":"San Isidro",
     "wof:parent_id":421167885,
     "wof:placetype":"localadmin",

--- a/data/421/170/251/421170251.geojson
+++ b/data/421/170/251/421170251.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008845,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2ebba6f0a25f59167ffe56db8e84da5",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421170251,
-    "wof:lastmodified":1566708889,
+    "wof:lastmodified":1582381951,
     "wof:name":"Tilaran",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/170/303/421170303.geojson
+++ b/data/421/170/303/421170303.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008847,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0a9226a93d930a256f18b06dc69dcfd",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421170303,
-    "wof:lastmodified":1566708889,
+    "wof:lastmodified":1582381951,
     "wof:name":"Matina",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/170/397/421170397.geojson
+++ b/data/421/170/397/421170397.geojson
@@ -325,6 +325,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008851,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80163ad450ee91f545313b979ad07029",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         }
     ],
     "wof:id":421170397,
-    "wof:lastmodified":1566708888,
+    "wof:lastmodified":1582381950,
     "wof:name":"Heredia",
     "wof:parent_id":421183455,
     "wof:placetype":"locality",

--- a/data/421/171/355/421171355.geojson
+++ b/data/421/171/355/421171355.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7210ae208ba6a67182ed50aa9a77a66d",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171355,
-    "wof:lastmodified":1566708898,
+    "wof:lastmodified":1582381953,
     "wof:name":"Pococi",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/171/707/421171707.geojson
+++ b/data/421/171/707/421171707.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aefa2dbd56036ebd893e72c135e70307",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421171707,
-    "wof:lastmodified":1566708898,
+    "wof:lastmodified":1582381953,
     "wof:name":"Alvarado",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/171/711/421171711.geojson
+++ b/data/421/171/711/421171711.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cec16b71693ae7a53c75367043d525f7",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421171711,
-    "wof:lastmodified":1566708900,
+    "wof:lastmodified":1582381953,
     "wof:name":"Bagaces",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/171/715/421171715.geojson
+++ b/data/421/171/715/421171715.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efc4bdd3022591a0a0a0078a8e09985b",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421171715,
-    "wof:lastmodified":1566708899,
+    "wof:lastmodified":1582381953,
     "wof:name":"Coto Brus",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/171/717/421171717.geojson
+++ b/data/421/171/717/421171717.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d4737a81c99ea510e1c624f2c9bf739",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421171717,
-    "wof:lastmodified":1566708900,
+    "wof:lastmodified":1582381953,
     "wof:name":"Hojancha",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/171/723/421171723.geojson
+++ b/data/421/171/723/421171723.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b103a8f3563b357479666b0125095d41",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":421171723,
-    "wof:lastmodified":1566708899,
+    "wof:lastmodified":1582381953,
     "wof:name":"Fortuna",
     "wof:parent_id":421183457,
     "wof:placetype":"localadmin",

--- a/data/421/171/727/421171727.geojson
+++ b/data/421/171/727/421171727.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d85bf63cd6ea51768583f76efe17b81",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171727,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"Puente de Piedra",
     "wof:parent_id":421204089,
     "wof:placetype":"localadmin",

--- a/data/421/171/729/421171729.geojson
+++ b/data/421/171/729/421171729.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2dd21a09ec5eeac2ad1a99b04a8cc0b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421171729,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"Palmera",
     "wof:parent_id":421183457,
     "wof:placetype":"localadmin",

--- a/data/421/171/733/421171733.geojson
+++ b/data/421/171/733/421171733.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"07934b67f83375700de4bed1d7285191",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171733,
-    "wof:lastmodified":1566708899,
+    "wof:lastmodified":1582381953,
     "wof:name":"Puraba",
     "wof:parent_id":421202609,
     "wof:placetype":"localadmin",

--- a/data/421/171/735/421171735.geojson
+++ b/data/421/171/735/421171735.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7746f0c6bb5e2f3476e97c172fad76f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171735,
-    "wof:lastmodified":1566708899,
+    "wof:lastmodified":1582381953,
     "wof:name":"Patarra",
     "wof:parent_id":421190519,
     "wof:placetype":"localadmin",

--- a/data/421/171/739/421171739.geojson
+++ b/data/421/171/739/421171739.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aabcf60f25ccc01180a77c9276fac878",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171739,
-    "wof:lastmodified":1566708898,
+    "wof:lastmodified":1582381953,
     "wof:name":"Tierras Morenas",
     "wof:parent_id":421170251,
     "wof:placetype":"localadmin",

--- a/data/421/171/925/421171925.geojson
+++ b/data/421/171/925/421171925.geojson
@@ -450,6 +450,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008912,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56f6e8f447e004d9634620d8afd90c8f",
     "wof:hierarchy":[
         {
@@ -461,7 +464,7 @@
         }
     ],
     "wof:id":421171925,
-    "wof:lastmodified":1566708899,
+    "wof:lastmodified":1582381953,
     "wof:name":"San Jose",
     "wof:parent_id":85670391,
     "wof:placetype":"locality",

--- a/data/421/172/003/421172003.geojson
+++ b/data/421/172/003/421172003.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008915,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3923e0c5fc48a6acf4332984c21b198",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421172003,
-    "wof:lastmodified":1566708873,
+    "wof:lastmodified":1582381947,
     "wof:name":"Turrialba",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/172/005/421172005.geojson
+++ b/data/421/172/005/421172005.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008915,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"293eab128658ceb538872002bb55d1f3",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421172005,
-    "wof:lastmodified":1566708873,
+    "wof:lastmodified":1582381947,
     "wof:name":"Turrubares",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/172/007/421172007.geojson
+++ b/data/421/172/007/421172007.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008915,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"873e106107b73244300057163745872e",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421172007,
-    "wof:lastmodified":1566708872,
+    "wof:lastmodified":1582381947,
     "wof:name":"Upala",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/172/525/421172525.geojson
+++ b/data/421/172/525/421172525.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008945,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f269d3d87f2793ce1bc40051894c058",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421172525,
-    "wof:lastmodified":1566708873,
+    "wof:lastmodified":1582381947,
     "wof:name":"Sabanilla",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",

--- a/data/421/172/533/421172533.geojson
+++ b/data/421/172/533/421172533.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008946,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"024ac52419ffd5084ea422faa9429756",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172533,
-    "wof:lastmodified":1566708871,
+    "wof:lastmodified":1582381947,
     "wof:name":"Chomes",
     "wof:parent_id":1108693663,
     "wof:placetype":"localadmin",

--- a/data/421/172/633/421172633.geojson
+++ b/data/421/172/633/421172633.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008949,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fad566456a1ddf076d69d11456da4e65",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172633,
-    "wof:lastmodified":1566708872,
+    "wof:lastmodified":1582381947,
     "wof:name":"Copey",
     "wof:parent_id":421184839,
     "wof:placetype":"localadmin",

--- a/data/421/173/267/421173267.geojson
+++ b/data/421/173/267/421173267.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"123c8345d5730efee0302d9202be2501",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173267,
-    "wof:lastmodified":1566708865,
+    "wof:lastmodified":1582381944,
     "wof:name":"San Jose",
     "wof:parent_id":421204089,
     "wof:placetype":"localadmin",

--- a/data/421/173/269/421173269.geojson
+++ b/data/421/173/269/421173269.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"019dea60ddb6eb8e06d4877cf6dcb4cb",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421173269,
-    "wof:lastmodified":1566708865,
+    "wof:lastmodified":1582381944,
     "wof:name":"Santa Cruz",
     "wof:parent_id":421172003,
     "wof:placetype":"localadmin",

--- a/data/421/175/393/421175393.geojson
+++ b/data/421/175/393/421175393.geojson
@@ -137,6 +137,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44f55e53eacf728f323cc9a8c573df4e",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":421175393,
-    "wof:lastmodified":1566708877,
+    "wof:lastmodified":1582381948,
     "wof:name":"Naranjo",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/175/395/421175395.geojson
+++ b/data/421/175/395/421175395.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e090d9e2c2ff5848561c5af4ae4f364e",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421175395,
-    "wof:lastmodified":1566708877,
+    "wof:lastmodified":1582381948,
     "wof:name":"Nicoya",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/175/397/421175397.geojson
+++ b/data/421/175/397/421175397.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e7214c1928f2fe5360fbeb3d1d00296",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421175397,
-    "wof:lastmodified":1566708876,
+    "wof:lastmodified":1582381947,
     "wof:name":"Oreamuno",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/175/401/421175401.geojson
+++ b/data/421/175/401/421175401.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b587753d3d7c1abee989201cce9d0f9e",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421175401,
-    "wof:lastmodified":1566708876,
+    "wof:lastmodified":1582381947,
     "wof:name":"Puriscal",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/175/407/421175407.geojson
+++ b/data/421/175/407/421175407.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60143e96d5fc7243d6a3934bfce87487",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421175407,
-    "wof:lastmodified":1566708876,
+    "wof:lastmodified":1582381948,
     "wof:name":"Valverde Vega",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/175/409/421175409.geojson
+++ b/data/421/175/409/421175409.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d99b59d21aeb84fecb951a0f15fe341",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421175409,
-    "wof:lastmodified":1566708876,
+    "wof:lastmodified":1582381948,
     "wof:name":"Vazquez De Coronado",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/176/301/421176301.geojson
+++ b/data/421/176/301/421176301.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009104,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f858c99f64bddfa3c1de28798936e034",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":421176301,
-    "wof:lastmodified":1566708897,
+    "wof:lastmodified":1582381953,
     "wof:name":"Santiago",
     "wof:parent_id":421175401,
     "wof:placetype":"localadmin",

--- a/data/421/176/307/421176307.geojson
+++ b/data/421/176/307/421176307.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009104,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"78b91f25e02d6480d938311771a957d1",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421176307,
-    "wof:lastmodified":1566708897,
+    "wof:lastmodified":1582381953,
     "wof:name":"Orotina",
     "wof:parent_id":421203757,
     "wof:placetype":"localadmin",

--- a/data/421/176/715/421176715.geojson
+++ b/data/421/176/715/421176715.geojson
@@ -76,6 +76,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"66945a1031b42eb3f0dad446baadae12",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421176715,
-    "wof:lastmodified":1566708897,
+    "wof:lastmodified":1582381953,
     "wof:name":"Cachi",
     "wof:parent_id":421182145,
     "wof:placetype":"localadmin",

--- a/data/421/177/157/421177157.geojson
+++ b/data/421/177/157/421177157.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009135,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfd18d0e499288c6483b69093bd29d78",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421177157,
-    "wof:lastmodified":1566708890,
+    "wof:lastmodified":1582381951,
     "wof:name":"Guadalupe",
     "wof:parent_id":421167885,
     "wof:placetype":"localadmin",

--- a/data/421/177/159/421177159.geojson
+++ b/data/421/177/159/421177159.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009135,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"643230c8dfc7b86cca26b2d2f3c2f4c6",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421177159,
-    "wof:lastmodified":1566708890,
+    "wof:lastmodified":1582381951,
     "wof:name":"Sarchi Sur",
     "wof:parent_id":421175407,
     "wof:placetype":"localadmin",

--- a/data/421/177/423/421177423.geojson
+++ b/data/421/177/423/421177423.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009144,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"41deb94f2a9e60545554acde1d991fd6",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421177423,
-    "wof:lastmodified":1566708890,
+    "wof:lastmodified":1582381951,
     "wof:name":"Matina",
     "wof:parent_id":421170303,
     "wof:placetype":"localadmin",

--- a/data/421/178/325/421178325.geojson
+++ b/data/421/178/325/421178325.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009178,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fba542dede0b36a068af5463b158726a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421178325,
-    "wof:lastmodified":1566708895,
+    "wof:lastmodified":1582381952,
     "wof:name":"Santa Eulalia",
     "wof:parent_id":421202071,
     "wof:placetype":"localadmin",

--- a/data/421/179/213/421179213.geojson
+++ b/data/421/179/213/421179213.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009208,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0eebfe64ee6a0149367ee9309c2151c",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":421179213,
-    "wof:lastmodified":1566708895,
+    "wof:lastmodified":1582381952,
     "wof:name":"Mora",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/180/321/421180321.geojson
+++ b/data/421/180/321/421180321.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009252,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a96aca193896bc5189ccdfbbc2ae4a02",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421180321,
-    "wof:lastmodified":1566708863,
+    "wof:lastmodified":1582381944,
     "wof:name":"Hojancha",
     "wof:parent_id":421171717,
     "wof:placetype":"localadmin",

--- a/data/421/180/915/421180915.geojson
+++ b/data/421/180/915/421180915.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ced38c789e93bc3455d3783526ab4f2",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421180915,
-    "wof:lastmodified":1566708862,
+    "wof:lastmodified":1582381944,
     "wof:name":"San Pablo",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/180/917/421180917.geojson
+++ b/data/421/180/917/421180917.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"968393f7bc061ca54b258ce99d8b1bd8",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421180917,
-    "wof:lastmodified":1566708863,
+    "wof:lastmodified":1582381944,
     "wof:name":"San Rafael",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/180/919/421180919.geojson
+++ b/data/421/180/919/421180919.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84724789253a4531a61bd184ebf1b07f",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":421180919,
-    "wof:lastmodified":1566708862,
+    "wof:lastmodified":1582381944,
     "wof:name":"Santa Ana",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/180/921/421180921.geojson
+++ b/data/421/180/921/421180921.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c713c73f32cda4ffa1571aa13b70b2b",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421180921,
-    "wof:lastmodified":1566708863,
+    "wof:lastmodified":1582381944,
     "wof:name":"Naranjito",
     "wof:parent_id":421201601,
     "wof:placetype":"localadmin",

--- a/data/421/180/923/421180923.geojson
+++ b/data/421/180/923/421180923.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f3ad05c0e6442a901916bebe33c6ce6",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421180923,
-    "wof:lastmodified":1566708862,
+    "wof:lastmodified":1582381944,
     "wof:name":"Naranjo",
     "wof:parent_id":421175393,
     "wof:placetype":"localadmin",

--- a/data/421/180/925/421180925.geojson
+++ b/data/421/180/925/421180925.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d54179001cefda15a21a3e2d9448208d",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421180925,
-    "wof:lastmodified":1566708862,
+    "wof:lastmodified":1582381944,
     "wof:name":"Palmira",
     "wof:parent_id":421201613,
     "wof:placetype":"localadmin",

--- a/data/421/181/975/421181975.geojson
+++ b/data/421/181/975/421181975.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009314,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f5f462ed0ac28163eeb8af078036bfa1",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421181975,
-    "wof:lastmodified":1566708875,
+    "wof:lastmodified":1582381947,
     "wof:name":"Colon",
     "wof:parent_id":421179213,
     "wof:placetype":"localadmin",

--- a/data/421/182/071/421182071.geojson
+++ b/data/421/182/071/421182071.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009317,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cda15d53497c0474c9c54a60c774a652",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421182071,
-    "wof:lastmodified":1566708896,
+    "wof:lastmodified":1582381952,
     "wof:name":"Parrita",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/182/141/421182141.geojson
+++ b/data/421/182/141/421182141.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2449a06759b9118a4e3f01b07c249f3",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421182141,
-    "wof:lastmodified":1566708897,
+    "wof:lastmodified":1582381952,
     "wof:name":"Perez Zeledon",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/182/145/421182145.geojson
+++ b/data/421/182/145/421182145.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4aae59b7786fae0648c6dcbcdf3cc02f",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421182145,
-    "wof:lastmodified":1566708896,
+    "wof:lastmodified":1582381952,
     "wof:name":"Paraiso",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/183/455/421183455.geojson
+++ b/data/421/183/455/421183455.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009370,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2591330db3eaf7fa6b1edeeb2470377f",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421183455,
-    "wof:lastmodified":1566708892,
+    "wof:lastmodified":1582381951,
     "wof:name":"Heredia",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/183/457/421183457.geojson
+++ b/data/421/183/457/421183457.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009370,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7cefd8a1c21b1cbcf32c9335f7e1a9a",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":421183457,
-    "wof:lastmodified":1566708893,
+    "wof:lastmodified":1582381951,
     "wof:name":"San Carlos",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/183/461/421183461.geojson
+++ b/data/421/183/461/421183461.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009370,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5077e8552a3e7fbaee9a11765964f01",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421183461,
-    "wof:lastmodified":1566708893,
+    "wof:lastmodified":1582381952,
     "wof:name":"San Juan",
     "wof:parent_id":421167885,
     "wof:placetype":"localadmin",

--- a/data/421/184/625/421184625.geojson
+++ b/data/421/184/625/421184625.geojson
@@ -208,6 +208,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31dc02bb2f5765681797188d89d67289",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":421184625,
-    "wof:lastmodified":1566708887,
+    "wof:lastmodified":1582381950,
     "wof:name":"San Juan",
     "wof:parent_id":421185327,
     "wof:placetype":"localadmin",

--- a/data/421/184/731/421184731.geojson
+++ b/data/421/184/731/421184731.geojson
@@ -382,6 +382,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009420,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a720da2d7205e5c284858052d4743f7",
     "wof:hierarchy":[
         {
@@ -393,7 +396,7 @@
         }
     ],
     "wof:id":421184731,
-    "wof:lastmodified":1566708887,
+    "wof:lastmodified":1582381950,
     "wof:name":"San Antonio",
     "wof:parent_id":421175401,
     "wof:placetype":"localadmin",

--- a/data/421/184/839/421184839.geojson
+++ b/data/421/184/839/421184839.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009424,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48aedbb68adcfe51a9ee28e5149bbc99",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421184839,
-    "wof:lastmodified":1566708887,
+    "wof:lastmodified":1582381950,
     "wof:name":"Dota",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/185/053/421185053.geojson
+++ b/data/421/185/053/421185053.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a82703c4de3f887b958a173262c16e72",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421185053,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"San Pedro",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",

--- a/data/421/185/071/421185071.geojson
+++ b/data/421/185/071/421185071.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19bba3f9551624f2ea29d018814eb1db",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421185071,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"San Vicente",
     "wof:parent_id":421203271,
     "wof:placetype":"localadmin",

--- a/data/421/185/073/421185073.geojson
+++ b/data/421/185/073/421185073.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6344f22359318e9f64afdcfefc790f2",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421185073,
-    "wof:lastmodified":1566708902,
+    "wof:lastmodified":1582381954,
     "wof:name":"Santa Rosa",
     "wof:parent_id":421170251,
     "wof:placetype":"localadmin",

--- a/data/421/185/223/421185223.geojson
+++ b/data/421/185/223/421185223.geojson
@@ -637,6 +637,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009436,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5e0eb426780ee34d639e31ea881fcdb",
     "wof:hierarchy":[
         {
@@ -648,7 +651,7 @@
         }
     ],
     "wof:id":421185223,
-    "wof:lastmodified":1566708902,
+    "wof:lastmodified":1582381954,
     "wof:name":"Buenos Aires",
     "wof:parent_id":1108693653,
     "wof:placetype":"localadmin",

--- a/data/421/185/269/421185269.geojson
+++ b/data/421/185/269/421185269.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009437,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"692024d16d31b7164e07eda825df723f",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421185269,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"San Ignacio",
     "wof:parent_id":421167827,
     "wof:placetype":"localadmin",

--- a/data/421/185/327/421185327.geojson
+++ b/data/421/185/327/421185327.geojson
@@ -392,6 +392,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"881e2e2f0f325aa48bf72394d7fc2e65",
     "wof:hierarchy":[
         {
@@ -402,7 +405,7 @@
         }
     ],
     "wof:id":421185327,
-    "wof:lastmodified":1566708903,
+    "wof:lastmodified":1582381954,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/185/329/421185329.geojson
+++ b/data/421/185/329/421185329.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f00f6532ff5c19c427bd544b2c54093",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421185329,
-    "wof:lastmodified":1566708903,
+    "wof:lastmodified":1582381955,
     "wof:name":"Sarapiqui",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/185/331/421185331.geojson
+++ b/data/421/185/331/421185331.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dbb93d377c7443bc24bf56235843957",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421185331,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"Siquirres",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/185/333/421185333.geojson
+++ b/data/421/185/333/421185333.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f974e624d83ef787341996f3981c8d6e",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421185333,
-    "wof:lastmodified":1566708902,
+    "wof:lastmodified":1582381954,
     "wof:name":"Talamanca",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/185/335/421185335.geojson
+++ b/data/421/185/335/421185335.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1778ae93a942782afb4010f312f2ad18",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421185335,
-    "wof:lastmodified":1566708902,
+    "wof:lastmodified":1582381954,
     "wof:name":"Atenas",
     "wof:parent_id":421202071,
     "wof:placetype":"localadmin",

--- a/data/421/185/489/421185489.geojson
+++ b/data/421/185/489/421185489.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"958f4b6e9c518cd7514426745cd9f44f",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421185489,
-    "wof:lastmodified":1566708903,
+    "wof:lastmodified":1582381954,
     "wof:name":"Montes De Oro",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/185/689/421185689.geojson
+++ b/data/421/185/689/421185689.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009451,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a51a542e0ccababbb9014ce388df154",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421185689,
-    "wof:lastmodified":1566708901,
+    "wof:lastmodified":1582381954,
     "wof:name":"Zapote",
     "wof:parent_id":1108693671,
     "wof:placetype":"localadmin",

--- a/data/421/186/273/421186273.geojson
+++ b/data/421/186/273/421186273.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2999713f0ad0aa526e13119f40df48a0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421186273,
-    "wof:lastmodified":1566708873,
+    "wof:lastmodified":1582381947,
     "wof:name":"Matama",
     "wof:parent_id":421188065,
     "wof:placetype":"localadmin",

--- a/data/421/188/065/421188065.geojson
+++ b/data/421/188/065/421188065.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59537e6e66dd16de5767a0d6d1183d46",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421188065,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381946,
     "wof:name":"Limon",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/188/109/421188109.geojson
+++ b/data/421/188/109/421188109.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009534,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3375539b0398e632dc775861e1ca3ae5",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421188109,
-    "wof:lastmodified":1566708870,
+    "wof:lastmodified":1582381946,
     "wof:name":"Osa",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/188/115/421188115.geojson
+++ b/data/421/188/115/421188115.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009534,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f7a3b4250d8e9959cf81d27dbba9cdc",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421188115,
-    "wof:lastmodified":1566708871,
+    "wof:lastmodified":1582381947,
     "wof:name":"Escazu",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/188/117/421188117.geojson
+++ b/data/421/188/117/421188117.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009534,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efc15be02a04016c0633ebb4da888640",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421188117,
-    "wof:lastmodified":1566708870,
+    "wof:lastmodified":1582381946,
     "wof:name":"Esparza",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/188/119/421188119.geojson
+++ b/data/421/188/119/421188119.geojson
@@ -683,6 +683,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009534,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"904a341fb478f7f68f7616a317add470",
     "wof:hierarchy":[
         {
@@ -693,7 +696,7 @@
         }
     ],
     "wof:id":421188119,
-    "wof:lastmodified":1566708870,
+    "wof:lastmodified":1582381946,
     "wof:name":"Liberia",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/188/735/421188735.geojson
+++ b/data/421/188/735/421188735.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"087378cdc290884da96f65918395b1d9",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":421188735,
-    "wof:lastmodified":1566708871,
+    "wof:lastmodified":1582381946,
     "wof:name":"Llano Grande",
     "wof:parent_id":421189139,
     "wof:placetype":"localadmin",

--- a/data/421/188/737/421188737.geojson
+++ b/data/421/188/737/421188737.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5b9bc620da0033dde9657761c239235",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421188737,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381946,
     "wof:name":"Tierra Blanca",
     "wof:parent_id":421189139,
     "wof:placetype":"localadmin",

--- a/data/421/188/905/421188905.geojson
+++ b/data/421/188/905/421188905.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0bcbeb81b8fc7804d3b6ce20d9ac07cc",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421188905,
-    "wof:lastmodified":1566708871,
+    "wof:lastmodified":1582381947,
     "wof:name":"Calle Blancos",
     "wof:parent_id":421202607,
     "wof:placetype":"localadmin",

--- a/data/421/188/907/421188907.geojson
+++ b/data/421/188/907/421188907.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8fd6876d5e341001a775f5bc9fe12d20",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421188907,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381945,
     "wof:name":"Santa Cruz",
     "wof:parent_id":1108693669,
     "wof:placetype":"localadmin",

--- a/data/421/189/139/421189139.geojson
+++ b/data/421/189/139/421189139.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a198a525462d1b224fffdfe432a2a8d6",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421189139,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Cartago",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/189/141/421189141.geojson
+++ b/data/421/189/141/421189141.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1732284940da45d1fb944a48337738e4",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189141,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Bahia Ballena",
     "wof:parent_id":421188109,
     "wof:placetype":"localadmin",

--- a/data/421/189/143/421189143.geojson
+++ b/data/421/189/143/421189143.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e884fbf8c2bf728b990076d9c864cc28",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189143,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"Guacimo",
     "wof:parent_id":421204091,
     "wof:placetype":"localadmin",

--- a/data/421/189/145/421189145.geojson
+++ b/data/421/189/145/421189145.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"498c50ee13899d41a1209727d1c979ec",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189145,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"La Virgen",
     "wof:parent_id":421185329,
     "wof:placetype":"localadmin",

--- a/data/421/189/149/421189149.geojson
+++ b/data/421/189/149/421189149.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ab9650a6b7c5a8ba4b4d64a0caedcce",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421189149,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381945,
     "wof:name":"Corredores",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/189/153/421189153.geojson
+++ b/data/421/189/153/421189153.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3008bb3aa643dae14191c6de9d4860c5",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":421189153,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Laguna de Arenal",
     "wof:parent_id":421170251,
     "wof:placetype":"localadmin",

--- a/data/421/189/157/421189157.geojson
+++ b/data/421/189/157/421189157.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9888e14147d19a5253a4b56786855224",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421189157,
-    "wof:lastmodified":1566708866,
+    "wof:lastmodified":1582381944,
     "wof:name":"Parrita",
     "wof:parent_id":421182071,
     "wof:placetype":"localadmin",

--- a/data/421/189/159/421189159.geojson
+++ b/data/421/189/159/421189159.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c8af84963ba98cfa8a8405676d80c5de",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189159,
-    "wof:lastmodified":1566708866,
+    "wof:lastmodified":1582381945,
     "wof:name":"Potrero Cerrado",
     "wof:parent_id":421175397,
     "wof:placetype":"localadmin",

--- a/data/421/189/161/421189161.geojson
+++ b/data/421/189/161/421189161.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85e4b4bf8a7c7934c920a9e4d1736134",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421189161,
-    "wof:lastmodified":1566708866,
+    "wof:lastmodified":1582381945,
     "wof:name":"Puerto Viejo",
     "wof:parent_id":421185329,
     "wof:placetype":"localadmin",

--- a/data/421/189/163/421189163.geojson
+++ b/data/421/189/163/421189163.geojson
@@ -76,6 +76,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b1f5f1948ee97ec5a62af27b319a27a",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421189163,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Quepos",
     "wof:parent_id":421201601,
     "wof:placetype":"localadmin",

--- a/data/421/189/165/421189165.geojson
+++ b/data/421/189/165/421189165.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"550118d8957f9bd145d7a5c4bad9d937",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421189165,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Quesada",
     "wof:parent_id":421183457,
     "wof:placetype":"localadmin",

--- a/data/421/189/167/421189167.geojson
+++ b/data/421/189/167/421189167.geojson
@@ -382,6 +382,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50c9bf2a5a1d95e516dece3c67f65a2a",
     "wof:hierarchy":[
         {
@@ -393,7 +396,7 @@
         }
     ],
     "wof:id":421189167,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"San Antonio",
     "wof:parent_id":421175395,
     "wof:placetype":"localadmin",

--- a/data/421/189/171/421189171.geojson
+++ b/data/421/189/171/421189171.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8614e29f297d4c6d31b3d5dbf539b918",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189171,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381945,
     "wof:name":"Salitral",
     "wof:parent_id":421179213,
     "wof:placetype":"localadmin",

--- a/data/421/189/175/421189175.geojson
+++ b/data/421/189/175/421189175.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14c1288d3f53ab238b364c3309cc7aac",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421189175,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"San Joaquin",
     "wof:parent_id":421203269,
     "wof:placetype":"localadmin",

--- a/data/421/189/177/421189177.geojson
+++ b/data/421/189/177/421189177.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009612,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"45971072ed39b38c7be14a4b65049520",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189177,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"San Jose",
     "wof:parent_id":421172007,
     "wof:placetype":"localadmin",

--- a/data/421/189/179/421189179.geojson
+++ b/data/421/189/179/421189179.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98e7d18e1f5acf8a10f7cfda33398552",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189179,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381945,
     "wof:name":"San Juan Grande",
     "wof:parent_id":421188117,
     "wof:placetype":"localadmin",

--- a/data/421/189/183/421189183.geojson
+++ b/data/421/189/183/421189183.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ad733351a19812d5811828e0b1077d3",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421189183,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"San Marcos",
     "wof:parent_id":421169977,
     "wof:placetype":"localadmin",

--- a/data/421/189/185/421189185.geojson
+++ b/data/421/189/185/421189185.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f111b4f70cb265830f9272aeeb42315",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421189185,
-    "wof:lastmodified":1566708869,
+    "wof:lastmodified":1582381945,
     "wof:name":"Santa Lucia",
     "wof:parent_id":421193823,
     "wof:placetype":"localadmin",

--- a/data/421/189/187/421189187.geojson
+++ b/data/421/189/187/421189187.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d995e31cd82048bfee702de14aa0a88",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421189187,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"Santo Tomas",
     "wof:parent_id":421185327,
     "wof:placetype":"localadmin",

--- a/data/421/189/189/421189189.geojson
+++ b/data/421/189/189/421189189.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c10d8ec4d0ae7f091d9dc287006933b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189189,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"Savegre",
     "wof:parent_id":421201601,
     "wof:placetype":"localadmin",

--- a/data/421/189/193/421189193.geojson
+++ b/data/421/189/193/421189193.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4bd31597fd245c49b8b0fdc4f73b166b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421189193,
-    "wof:lastmodified":1566708866,
+    "wof:lastmodified":1582381945,
     "wof:name":"Sierra",
     "wof:parent_id":421190515,
     "wof:placetype":"localadmin",

--- a/data/421/189/195/421189195.geojson
+++ b/data/421/189/195/421189195.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"112121f25488d60d760e05481bf10427",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421189195,
-    "wof:lastmodified":1566708866,
+    "wof:lastmodified":1582381945,
     "wof:name":"Sixaola",
     "wof:parent_id":421185333,
     "wof:placetype":"localadmin",

--- a/data/421/189/197/421189197.geojson
+++ b/data/421/189/197/421189197.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69ef8bf59d11b53c427da3566b501091",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421189197,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Turrialba",
     "wof:parent_id":421172003,
     "wof:placetype":"localadmin",

--- a/data/421/189/199/421189199.geojson
+++ b/data/421/189/199/421189199.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"033b8e1e7a66a415e90923c3d28e2bf6",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421189199,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Santa Rosa",
     "wof:parent_id":421175397,
     "wof:placetype":"localadmin",

--- a/data/421/189/203/421189203.geojson
+++ b/data/421/189/203/421189203.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c770dd8651b866fadf89894392db6f3d",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189203,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"Ventisiete de Abril",
     "wof:parent_id":1108693669,
     "wof:placetype":"localadmin",

--- a/data/421/189/205/421189205.geojson
+++ b/data/421/189/205/421189205.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d903907ab6660e47c51d9ec074534e67",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421189205,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"Ulloa",
     "wof:parent_id":421183455,
     "wof:placetype":"localadmin",

--- a/data/421/189/207/421189207.geojson
+++ b/data/421/189/207/421189207.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"793c8cabaa3935ed85819f1491c20921",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189207,
-    "wof:lastmodified":1566708868,
+    "wof:lastmodified":1582381945,
     "wof:name":"Uruca",
     "wof:parent_id":421180919,
     "wof:placetype":"localadmin",

--- a/data/421/189/503/421189503.geojson
+++ b/data/421/189/503/421189503.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b86c865e203709c40b089dedb93e502a",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421189503,
-    "wof:lastmodified":1566708867,
+    "wof:lastmodified":1582381945,
     "wof:name":"Limoncito",
     "wof:parent_id":421171715,
     "wof:placetype":"localadmin",

--- a/data/421/189/505/421189505.geojson
+++ b/data/421/189/505/421189505.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9bdfee6e37a4516d8b866a773e29627",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421189505,
-    "wof:lastmodified":1566708866,
+    "wof:lastmodified":1582381945,
     "wof:name":"Llorente",
     "wof:parent_id":421197833,
     "wof:placetype":"localadmin",

--- a/data/421/190/515/421190515.geojson
+++ b/data/421/190/515/421190515.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a77f73cc2bd75ff56e234a7ce9bec0ab",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421190515,
-    "wof:lastmodified":1566708880,
+    "wof:lastmodified":1582381949,
     "wof:name":"Abangares",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/190/519/421190519.geojson
+++ b/data/421/190/519/421190519.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f364901b8c36f38ecf9ce4bffc25dcb",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421190519,
-    "wof:lastmodified":1566708880,
+    "wof:lastmodified":1582381949,
     "wof:name":"Desamparados",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/190/521/421190521.geojson
+++ b/data/421/190/521/421190521.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92e74ee5a972cd80430a11fb1e8ebdfd",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":421190521,
-    "wof:lastmodified":1534379263,
+    "wof:lastmodified":1582381949,
     "wof:name":"San Antonio",
     "wof:parent_id":421201603,
     "wof:placetype":"localadmin",

--- a/data/421/191/223/421191223.geojson
+++ b/data/421/191/223/421191223.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"20664e536c8413ec9ee618880d73a8bb",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191223,
-    "wof:lastmodified":1566708879,
+    "wof:lastmodified":1582381948,
     "wof:name":"Santa Elena",
     "wof:parent_id":421170049,
     "wof:placetype":"localadmin",

--- a/data/421/191/229/421191229.geojson
+++ b/data/421/191/229/421191229.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0755a0cd4331a7f94160e0ebea7a279",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421191229,
-    "wof:lastmodified":1566708878,
+    "wof:lastmodified":1582381948,
     "wof:name":"San Pablo",
     "wof:parent_id":421193823,
     "wof:placetype":"localadmin",

--- a/data/421/191/231/421191231.geojson
+++ b/data/421/191/231/421191231.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7bf095a840cd7840fdbbd18881e13390",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191231,
-    "wof:lastmodified":1566708879,
+    "wof:lastmodified":1582381948,
     "wof:name":"Tures",
     "wof:parent_id":1108693667,
     "wof:placetype":"localadmin",

--- a/data/421/191/481/421191481.geojson
+++ b/data/421/191/481/421191481.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a77b252167fe31478af948fe1cb83835",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421191481,
-    "wof:lastmodified":1566708879,
+    "wof:lastmodified":1582381948,
     "wof:name":"Florencia",
     "wof:parent_id":421183457,
     "wof:placetype":"localadmin",

--- a/data/421/191/987/421191987.geojson
+++ b/data/421/191/987/421191987.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009722,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc3dec03a0a7f601cbc9dcb6a73d0735",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":421191987,
-    "wof:lastmodified":1566708879,
+    "wof:lastmodified":1582381948,
     "wof:name":"Concepci\u00f3n",
     "wof:parent_id":1108693667,
     "wof:placetype":"locality",

--- a/data/421/192/973/421192973.geojson
+++ b/data/421/192/973/421192973.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009755,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f9dc67fb6c7202eb10864dcbee819fc7",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421192973,
-    "wof:lastmodified":1566708848,
+    "wof:lastmodified":1582381940,
     "wof:name":"Filadelfia",
     "wof:parent_id":1108693669,
     "wof:placetype":"localadmin",

--- a/data/421/193/029/421193029.geojson
+++ b/data/421/193/029/421193029.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009757,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e055aa8dc25e7e75fca002da30a34c6",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421193029,
-    "wof:lastmodified":1566708851,
+    "wof:lastmodified":1582381941,
     "wof:name":"Tambor",
     "wof:parent_id":421201603,
     "wof:placetype":"localadmin",

--- a/data/421/193/373/421193373.geojson
+++ b/data/421/193/373/421193373.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009769,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1e7ae21de538d3a7676be164ae149bd",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421193373,
-    "wof:lastmodified":1566708852,
+    "wof:lastmodified":1582381941,
     "wof:name":"San Isidro de El General",
     "wof:parent_id":421182141,
     "wof:placetype":"localadmin",

--- a/data/421/193/823/421193823.geojson
+++ b/data/421/193/823/421193823.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009784,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1b25600f91b453730d3c08d89474e6a",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421193823,
-    "wof:lastmodified":1566708851,
+    "wof:lastmodified":1582381941,
     "wof:name":"Barva",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/193/875/421193875.geojson
+++ b/data/421/193/875/421193875.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009785,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba597bcf1c16dba7f5c7bc604e22e9b8",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421193875,
-    "wof:lastmodified":1566708851,
+    "wof:lastmodified":1582381941,
     "wof:name":"San Josecito",
     "wof:parent_id":421193823,
     "wof:placetype":"localadmin",

--- a/data/421/194/119/421194119.geojson
+++ b/data/421/194/119/421194119.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009794,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b023722c6cabab053ef9ff65d87a746a",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421194119,
-    "wof:lastmodified":1566708849,
+    "wof:lastmodified":1582381940,
     "wof:name":"Poas",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/194/697/421194697.geojson
+++ b/data/421/194/697/421194697.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009816,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ac3920ce41fd5d967a344e77e870e47",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421194697,
-    "wof:lastmodified":1566708850,
+    "wof:lastmodified":1582381941,
     "wof:name":"Golfito",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/195/379/421195379.geojson
+++ b/data/421/195/379/421195379.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b89f51a409768b68058d525ec510fa8a",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":421195379,
-    "wof:lastmodified":1566708848,
+    "wof:lastmodified":1582381940,
     "wof:name":"San Rafael",
     "wof:parent_id":421204093,
     "wof:placetype":"localadmin",

--- a/data/421/195/559/421195559.geojson
+++ b/data/421/195/559/421195559.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009852,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64ad3152e31af6689bf5d88fbda64ac0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195559,
-    "wof:lastmodified":1566708848,
+    "wof:lastmodified":1582381940,
     "wof:name":"Bratsi",
     "wof:parent_id":421185333,
     "wof:placetype":"localadmin",

--- a/data/421/195/571/421195571.geojson
+++ b/data/421/195/571/421195571.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009852,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9f26e767090b0856e2badfa556324a7d",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421195571,
-    "wof:lastmodified":1566708849,
+    "wof:lastmodified":1582381940,
     "wof:name":"Granja",
     "wof:parent_id":421203763,
     "wof:placetype":"localadmin",

--- a/data/421/195/587/421195587.geojson
+++ b/data/421/195/587/421195587.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009853,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"718e924f7707bd40b185c84ed59b1953",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195587,
-    "wof:lastmodified":1566708848,
+    "wof:lastmodified":1582381940,
     "wof:name":"Paramo",
     "wof:parent_id":421182141,
     "wof:placetype":"localadmin",

--- a/data/421/195/591/421195591.geojson
+++ b/data/421/195/591/421195591.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009853,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc2be2072210d705ff012c8fad0ef8e9",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421195591,
-    "wof:lastmodified":1566708848,
+    "wof:lastmodified":1582381940,
     "wof:name":"San Rafael",
     "wof:parent_id":421204569,
     "wof:placetype":"localadmin",

--- a/data/421/196/549/421196549.geojson
+++ b/data/421/196/549/421196549.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"835612cebcf2ca9834041cf1b3ef7303",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421196549,
-    "wof:lastmodified":1566708878,
+    "wof:lastmodified":1582381948,
     "wof:name":"Concepcion",
     "wof:parent_id":421202071,
     "wof:placetype":"localadmin",

--- a/data/421/196/997/421196997.geojson
+++ b/data/421/196/997/421196997.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"474d9d204ca9323fb3efc6d580190c83",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421196997,
-    "wof:lastmodified":1566708878,
+    "wof:lastmodified":1582381948,
     "wof:name":"Rivas",
     "wof:parent_id":421182141,
     "wof:placetype":"localadmin",

--- a/data/421/197/001/421197001.geojson
+++ b/data/421/197/001/421197001.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a6f8babfc11c92b54bef62f85fcd439",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421197001,
-    "wof:lastmodified":1566708881,
+    "wof:lastmodified":1582381949,
     "wof:name":"Rio Blanco",
     "wof:parent_id":421188065,
     "wof:placetype":"localadmin",

--- a/data/421/197/063/421197063.geojson
+++ b/data/421/197/063/421197063.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ce302491a7be885de0aacc9d4de7c73",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421197063,
-    "wof:lastmodified":1566708881,
+    "wof:lastmodified":1582381949,
     "wof:name":"Cuajiniquil",
     "wof:parent_id":1108693669,
     "wof:placetype":"localadmin",

--- a/data/421/197/121/421197121.geojson
+++ b/data/421/197/121/421197121.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009903,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"786e84f084797efc44ac63b21d2fd080",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":421197121,
-    "wof:lastmodified":1566708882,
+    "wof:lastmodified":1582381949,
     "wof:name":"Paquera",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/421/197/131/421197131.geojson
+++ b/data/421/197/131/421197131.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009903,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af5465ba04178f8253202bd6ced7e5a1",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421197131,
-    "wof:lastmodified":1566708882,
+    "wof:lastmodified":1582381949,
     "wof:name":"Puerto Jimenez",
     "wof:parent_id":421194697,
     "wof:placetype":"localadmin",

--- a/data/421/197/487/421197487.geojson
+++ b/data/421/197/487/421197487.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009915,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5475397dd5c74292d1c2140359af7ed2",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421197487,
-    "wof:lastmodified":1566708882,
+    "wof:lastmodified":1582381949,
     "wof:name":"Guabito",
     "wof:parent_id":421185333,
     "wof:placetype":"localadmin",

--- a/data/421/197/833/421197833.geojson
+++ b/data/421/197/833/421197833.geojson
@@ -340,6 +340,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009926,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e82d2501b4c2d9de26d5539a678ac4fe",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         }
     ],
     "wof:id":421197833,
-    "wof:lastmodified":1566708881,
+    "wof:lastmodified":1582381949,
     "wof:name":"Belen",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/198/139/421198139.geojson
+++ b/data/421/198/139/421198139.geojson
@@ -613,6 +613,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009938,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4980ab61037f468a1ee48d31c85625b7",
     "wof:hierarchy":[
         {
@@ -624,7 +627,7 @@
         }
     ],
     "wof:id":421198139,
-    "wof:lastmodified":1566708877,
+    "wof:lastmodified":1582381948,
     "wof:name":"Cairo",
     "wof:parent_id":421185331,
     "wof:placetype":"localadmin",

--- a/data/421/198/561/421198561.geojson
+++ b/data/421/198/561/421198561.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009952,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b03d77e247fc8960dfe8040daed2ec57",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421198561,
-    "wof:lastmodified":1566708877,
+    "wof:lastmodified":1582381948,
     "wof:name":"Curubande",
     "wof:parent_id":421188119,
     "wof:placetype":"localadmin",

--- a/data/421/199/285/421199285.geojson
+++ b/data/421/199/285/421199285.geojson
@@ -280,6 +280,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbeaf4acaa1c2f429f7e2525dda32a44",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         }
     ],
     "wof:id":421199285,
-    "wof:lastmodified":1566708883,
+    "wof:lastmodified":1582381949,
     "wof:name":"San Jose",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/199/323/421199323.geojson
+++ b/data/421/199/323/421199323.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459009985,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"953a1a5b5b347d86d92399fbe96b7f8a",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421199323,
-    "wof:lastmodified":1566708883,
+    "wof:lastmodified":1582381949,
     "wof:name":"San Rafael",
     "wof:parent_id":421201603,
     "wof:placetype":"locality",

--- a/data/421/200/095/421200095.geojson
+++ b/data/421/200/095/421200095.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d02ceb760f6ca9310d94e08a94d9f80",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421200095,
-    "wof:lastmodified":1566708884,
+    "wof:lastmodified":1582381949,
     "wof:name":"Carrandi",
     "wof:parent_id":421170303,
     "wof:placetype":"localadmin",

--- a/data/421/200/097/421200097.geojson
+++ b/data/421/200/097/421200097.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad7ac55311e66d68677b2b14624665bc",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421200097,
-    "wof:lastmodified":1566708883,
+    "wof:lastmodified":1582381949,
     "wof:name":"Juntas",
     "wof:parent_id":421190515,
     "wof:placetype":"localadmin",

--- a/data/421/201/601/421201601.geojson
+++ b/data/421/201/601/421201601.geojson
@@ -173,6 +173,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9c083dae2985e930229144ed1613a70",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":421201601,
-    "wof:lastmodified":1566708886,
+    "wof:lastmodified":1582381950,
     "wof:name":"Aguirre",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/201/603/421201603.geojson
+++ b/data/421/201/603/421201603.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca934e0c00368a9a1755d99c0abac1de",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421201603,
-    "wof:lastmodified":1566708885,
+    "wof:lastmodified":1582381950,
     "wof:name":"Alajuela",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/201/605/421201605.geojson
+++ b/data/421/201/605/421201605.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d221985ec8bd88d63811abd18bf385ea",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421201605,
-    "wof:lastmodified":1566708884,
+    "wof:lastmodified":1582381949,
     "wof:name":"Alajuelita",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/201/613/421201613.geojson
+++ b/data/421/201/613/421201613.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4811fad5a2a1f85835e6db325c204a85",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421201613,
-    "wof:lastmodified":1566708885,
+    "wof:lastmodified":1582381950,
     "wof:name":"Canas",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/201/615/421201615.geojson
+++ b/data/421/201/615/421201615.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db13b5a0d0999987dcf998e5900e4df0",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421201615,
-    "wof:lastmodified":1566708886,
+    "wof:lastmodified":1582381950,
     "wof:name":"Carrillo",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/201/617/421201617.geojson
+++ b/data/421/201/617/421201617.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f7e350f4d7691fe12d1ebd98cefeb5d",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421201617,
-    "wof:lastmodified":1566708884,
+    "wof:lastmodified":1582381949,
     "wof:name":"Concepcion",
     "wof:parent_id":421180917,
     "wof:placetype":"localadmin",

--- a/data/421/201/619/421201619.geojson
+++ b/data/421/201/619/421201619.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50b01a65a9c9912b94e8a1fdf6574027",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421201619,
-    "wof:lastmodified":1566708884,
+    "wof:lastmodified":1582381949,
     "wof:name":"Esquipulas",
     "wof:parent_id":421203763,
     "wof:placetype":"localadmin",

--- a/data/421/201/621/421201621.geojson
+++ b/data/421/201/621/421201621.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e920297a3613466a2ea357b271e5af5",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421201621,
-    "wof:lastmodified":1566708884,
+    "wof:lastmodified":1582381949,
     "wof:name":"Guapiles",
     "wof:parent_id":421171355,
     "wof:placetype":"localadmin",

--- a/data/421/201/623/421201623.geojson
+++ b/data/421/201/623/421201623.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010078,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fdab3d0bb76b55294ba96adeb3fca575",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421201623,
-    "wof:lastmodified":1566708886,
+    "wof:lastmodified":1582381950,
     "wof:name":"San Isidro",
     "wof:parent_id":421175409,
     "wof:placetype":"localadmin",

--- a/data/421/202/071/421202071.geojson
+++ b/data/421/202/071/421202071.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010104,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2478c158352dfe5a979d61864220c4c",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421202071,
-    "wof:lastmodified":1566708860,
+    "wof:lastmodified":1582381944,
     "wof:name":"Atenas",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/202/319/421202319.geojson
+++ b/data/421/202/319/421202319.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010113,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b9f3a4a233a19dcdc9f3dae3c6d5aed",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421202319,
-    "wof:lastmodified":1566708861,
+    "wof:lastmodified":1582381944,
     "wof:name":"Tronadora",
     "wof:parent_id":421170251,
     "wof:placetype":"localadmin",

--- a/data/421/202/607/421202607.geojson
+++ b/data/421/202/607/421202607.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9248d40e30facedba1cfebc08f3adb8e",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421202607,
-    "wof:lastmodified":1566708861,
+    "wof:lastmodified":1582381944,
     "wof:name":"Tibas",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/202/609/421202609.geojson
+++ b/data/421/202/609/421202609.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67d00777ab435d42ba3da5f78a532225",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":421202609,
-    "wof:lastmodified":1566708861,
+    "wof:lastmodified":1582381944,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/202/611/421202611.geojson
+++ b/data/421/202/611/421202611.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"999c1e71e5c1cc34727ab023dfa2f756",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421202611,
-    "wof:lastmodified":1566708860,
+    "wof:lastmodified":1582381944,
     "wof:name":"Limon",
     "wof:parent_id":421188065,
     "wof:placetype":"localadmin",

--- a/data/421/202/613/421202613.geojson
+++ b/data/421/202/613/421202613.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe7a5cd8cc8ed978d274d2a7bab15094",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":421202613,
-    "wof:lastmodified":1566708860,
+    "wof:lastmodified":1582381944,
     "wof:name":"Santa Ana",
     "wof:parent_id":421180919,
     "wof:placetype":"localadmin",

--- a/data/421/202/615/421202615.geojson
+++ b/data/421/202/615/421202615.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f56772c809fbd5e0dd33a5df90e1a07",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":421202615,
-    "wof:lastmodified":1566708860,
+    "wof:lastmodified":1582381944,
     "wof:name":"Tamarindo",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/421/202/617/421202617.geojson
+++ b/data/421/202/617/421202617.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8894bb5bd1ac0084e422e86bec63bdaf",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421202617,
-    "wof:lastmodified":1566708859,
+    "wof:lastmodified":1582381944,
     "wof:name":"Toro Amarillo",
     "wof:parent_id":421175407,
     "wof:placetype":"localadmin",

--- a/data/421/202/621/421202621.geojson
+++ b/data/421/202/621/421202621.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b79e209a221323b4f287ced9c5c0c8d",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421202621,
-    "wof:lastmodified":1566708859,
+    "wof:lastmodified":1582381944,
     "wof:name":"Vara Blanca",
     "wof:parent_id":421201603,
     "wof:placetype":"localadmin",

--- a/data/421/202/623/421202623.geojson
+++ b/data/421/202/623/421202623.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1fe1f4d0b04f97c39cc6aaf7bac6dc7",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421202623,
-    "wof:lastmodified":1566708860,
+    "wof:lastmodified":1582381944,
     "wof:name":"Venado",
     "wof:parent_id":421183457,
     "wof:placetype":"localadmin",

--- a/data/421/202/711/421202711.geojson
+++ b/data/421/202/711/421202711.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010127,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f93ea09554fb8128b3fc71dd9aa421f2",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421202711,
-    "wof:lastmodified":1566708861,
+    "wof:lastmodified":1582381944,
     "wof:name":"Bejuco",
     "wof:parent_id":1108693661,
     "wof:placetype":"localadmin",

--- a/data/421/203/269/421203269.geojson
+++ b/data/421/203/269/421203269.geojson
@@ -279,6 +279,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010145,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7774032f46d6c70887388d4bc1d71b6",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         }
     ],
     "wof:id":421203269,
-    "wof:lastmodified":1566708858,
+    "wof:lastmodified":1582381943,
     "wof:name":"Flores",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/203/271/421203271.geojson
+++ b/data/421/203/271/421203271.geojson
@@ -329,6 +329,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010145,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84d222f174977c8bdf8906fdab3efb63",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
         }
     ],
     "wof:id":421203271,
-    "wof:lastmodified":1566708859,
+    "wof:lastmodified":1582381944,
     "wof:name":"Moravia",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/203/755/421203755.geojson
+++ b/data/421/203/755/421203755.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d5c0ad1ae1c792693e88a733eb505eb",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421203755,
-    "wof:lastmodified":1566708858,
+    "wof:lastmodified":1582381943,
     "wof:name":"Curridabat",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/203/757/421203757.geojson
+++ b/data/421/203/757/421203757.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4b062976a814770b225dc9b288e10c4",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421203757,
-    "wof:lastmodified":1566708859,
+    "wof:lastmodified":1582381943,
     "wof:name":"Orotina",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/203/763/421203763.geojson
+++ b/data/421/203/763/421203763.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d3be9030eef37e2e241998055e93532",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421203763,
-    "wof:lastmodified":1566708858,
+    "wof:lastmodified":1582381943,
     "wof:name":"Palmares",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/204/087/421204087.geojson
+++ b/data/421/204/087/421204087.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010173,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"755b499927606bae7677aeeb2327cb8a",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421204087,
-    "wof:lastmodified":1566708857,
+    "wof:lastmodified":1582381943,
     "wof:name":"Garabito",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/204/089/421204089.geojson
+++ b/data/421/204/089/421204089.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010173,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ded3939e71f5006f608ee6a429bf3d0",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421204089,
-    "wof:lastmodified":1566708856,
+    "wof:lastmodified":1582381943,
     "wof:name":"Grecia",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/204/091/421204091.geojson
+++ b/data/421/204/091/421204091.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010173,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1507e8465dbff80f19a5e6adf8b29ec0",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421204091,
-    "wof:lastmodified":1566708856,
+    "wof:lastmodified":1582381943,
     "wof:name":"Guacimo",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/204/093/421204093.geojson
+++ b/data/421/204/093/421204093.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010173,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e52b2566d5b16f46d4cf8a657ea96c58",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421204093,
-    "wof:lastmodified":1566708857,
+    "wof:lastmodified":1582381943,
     "wof:name":"Guatuso",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/204/569/421204569.geojson
+++ b/data/421/204/569/421204569.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"CR",
     "wof:created":1459010190,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a26545d18aaef507f8709e9b861c8f7f",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":421204569,
-    "wof:lastmodified":1566708856,
+    "wof:lastmodified":1582381943,
     "wof:name":"La Union",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/856/324/87/85632487.geojson
+++ b/data/856/324/87/85632487.geojson
@@ -950,6 +950,11 @@
     },
     "wof:country":"CR",
     "wof:country_alpha3":"CRI",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"b8ca0d65a4667d13f1ed83ddc9ea0224",
     "wof:hierarchy":[
         {
@@ -964,7 +969,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708753,
+    "wof:lastmodified":1582381932,
     "wof:name":"Costa Rica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/703/71/85670371.geojson
+++ b/data/856/703/71/85670371.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Cartago Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0cfa4b88c920289bb71ba2e24972df4c",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708760,
+    "wof:lastmodified":1582381937,
     "wof:name":"Cartago",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/75/85670375.geojson
+++ b/data/856/703/75/85670375.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Heredia Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb7e35658e0d7c37d3c8256cf0c50767",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708754,
+    "wof:lastmodified":1582381933,
     "wof:name":"Heredia",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/81/85670381.geojson
+++ b/data/856/703/81/85670381.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Lim\u00f3n Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"952b16b4d170e447ad371ffa2e5e90dc",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708754,
+    "wof:lastmodified":1582381933,
     "wof:name":"Lim\u00f3n",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/85/85670385.geojson
+++ b/data/856/703/85/85670385.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Puntarenas Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f091360896830ea75d74fb3678dc53c",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708757,
+    "wof:lastmodified":1582381935,
     "wof:name":"Puntarenas",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/91/85670391.geojson
+++ b/data/856/703/91/85670391.geojson
@@ -327,6 +327,9 @@
         "wk:page":"San Jos\u00e9 Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7177bdce3b2e24663e86a3e8ded8c9b2",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708755,
+    "wof:lastmodified":1582381934,
     "wof:name":"San Jos\u00e9",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/93/85670393.geojson
+++ b/data/856/703/93/85670393.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Alajuela Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8d762bba6841c113f3c5cec1b33ef74",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708754,
+    "wof:lastmodified":1582381933,
     "wof:name":"Alajuela",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/99/85670399.geojson
+++ b/data/856/703/99/85670399.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Guanacaste Province"
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfec01ae8d660616bc0fffd58f1a8934",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566708756,
+    "wof:lastmodified":1582381934,
     "wof:name":"Guanacaste",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/857/639/37/85763937.geojson
+++ b/data/857/639/37/85763937.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":228529
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09316540920309ca1d219e22c96137ba",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708753,
+    "wof:lastmodified":1582381932,
     "wof:name":"M\u00e9xico",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/55/85765755.geojson
+++ b/data/857/657/55/85765755.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":230469
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb9fe990de050bb756f93ac599c0904e",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708753,
+    "wof:lastmodified":1582381931,
     "wof:name":"Arpaza",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/59/85765759.geojson
+++ b/data/857/657/59/85765759.geojson
@@ -109,6 +109,9 @@
         "qs_pg:id":986126
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82c6364be78ca60594db65940197f924",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Pradera",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/65/85765765.geojson
+++ b/data/857/657/65/85765765.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":224732
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b677292e90fe4f1a18c96a48a34034b7",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Yoses Sur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/69/85765769.geojson
+++ b/data/857/657/69/85765769.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":896299
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddc650e811554ba2fa95006a3f590b1f",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Ujarraz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/71/85765771.geojson
+++ b/data/857/657/71/85765771.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":896294
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bddf1e1f85c930fcc0372d5ac20c9a2",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708753,
+    "wof:lastmodified":1582381931,
     "wof:name":"Seguro Social",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/75/85765775.geojson
+++ b/data/857/657/75/85765775.geojson
@@ -115,6 +115,9 @@
         "qs_pg:id":346804
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf5a19910a95cabea00b7d7cdb3eea15",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Soledad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/81/85765781.geojson
+++ b/data/857/657/81/85765781.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":889892
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"953d8f2500092954e79a1c5d21867d8e",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Dolorosa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/85/85765785.geojson
+++ b/data/857/657/85/85765785.geojson
@@ -69,6 +69,9 @@
         "gp:id":22723693
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a42573641234a1ee8d133866dff11b04",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708753,
+    "wof:lastmodified":1582381931,
     "wof:name":"Morazan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/89/85765789.geojson
+++ b/data/857/657/89/85765789.geojson
@@ -396,6 +396,9 @@
         "qs_pg:id":889894
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f66faabf6fddb98a00c058f4296c3920",
     "wof:hierarchy":[
         {
@@ -411,7 +414,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Coca Cola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/93/85765793.geojson
+++ b/data/857/657/93/85765793.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1268078
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5ecefd38f8e05bb163d2c66d32c6e4b",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Juarez",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/07/85765807.geojson
+++ b/data/857/658/07/85765807.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1196558
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3b03bdf5531b801c6bccbb76d742c1d",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Tournon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/11/85765811.geojson
+++ b/data/857/658/11/85765811.geojson
@@ -115,6 +115,9 @@
         "qs_pg:id":1310048
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c98447a2fe57f914bb6f848ca61c2dc5",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Pueblo Nuevo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/13/85765813.geojson
+++ b/data/857/658/13/85765813.geojson
@@ -125,6 +125,9 @@
         "qs_pg:id":946555
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2d9750fcdfc0d7e5e5a1ae4008a4f3b",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Santa Catalina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/19/85765819.geojson
+++ b/data/857/658/19/85765819.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":237727
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15fe7c2e1362c3fe0749a3855b379b44",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Virilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/23/85765823.geojson
+++ b/data/857/658/23/85765823.geojson
@@ -675,6 +675,9 @@
         "qs_pg:id":237728
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc2de84f87ff71999720d63d25772bc4",
     "wof:hierarchy":[
         {
@@ -690,7 +693,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Americas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/27/85765827.geojson
+++ b/data/857/658/27/85765827.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":268824
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"137a41cdee7c719c2a2dc82d91b7aadd",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Robledal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/31/85765831.geojson
+++ b/data/857/658/31/85765831.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":986127
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cbaaf4abe5ab59e1d1a8097b6a36ca45",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Rohrmoser",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/35/85765835.geojson
+++ b/data/857/658/35/85765835.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":986128
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec2915fe4174b31d95ee29d8b41b9af7",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Favorita Sur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/39/85765839.geojson
+++ b/data/857/658/39/85765839.geojson
@@ -424,6 +424,9 @@
         "qs_pg:id":366560
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5ef0bd112175714acf08384d85bf529",
     "wof:hierarchy":[
         {
@@ -439,7 +442,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Palermo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/43/85765843.geojson
+++ b/data/857/658/43/85765843.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":1000754
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7268a57cfe31f682b6823ba3b9d31e5b",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Perpetuo Socorro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/47/85765847.geojson
+++ b/data/857/658/47/85765847.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":366561
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d365432e133fd1a55a5fe81c9e7ea546",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Paseo Colon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/49/85765849.geojson
+++ b/data/857/658/49/85765849.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1087512
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d4224b39df76d5a1ec8dd4f676e0494",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Mantica",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/55/85765855.geojson
+++ b/data/857/658/55/85765855.geojson
@@ -73,6 +73,9 @@
         "gp:id":22723840
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa53b5cffdbb39250f0d1278fc8f0a4a",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"San Bosco",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/59/85765859.geojson
+++ b/data/857/658/59/85765859.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":346809
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab47eeece92192b8b29ffff641b50202",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Hatillo No.5",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/63/85765863.geojson
+++ b/data/857/658/63/85765863.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":264773
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"385a887b9c8433ad90db4ccdf27bde23",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708752,
+    "wof:lastmodified":1582381931,
     "wof:name":"Hatillo No.3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/658/67/85765867.geojson
+++ b/data/857/658/67/85765867.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1154422
     },
     "wof:country":"CR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5190b61a7a8ffff1ba58d1dd85254749",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566708751,
+    "wof:lastmodified":1582381931,
     "wof:name":"Flor Natalia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.