### PR TITLE
cr concordances, placetype local, and more

### DIFF
--- a/data/110/869/365/3/1108693653.geojson
+++ b/data/110/869/365/3/1108693653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196017,
-    "geom:area_square_m":2393214460.321071,
+    "geom:area_square_m":2393214460.321082,
     "geom:bbox":"-83.5635993504,8.77523706306,-82.9686272656,9.38421813763",
     "geom:latitude":9.108424,
     "geom:longitude":-83.250521,
@@ -648,9 +648,10 @@
     "wof:concordances":{
         "hasc:id":"CR.PU.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414942,
-    "wof:geomhash":"db25bce58db9fa1c1213be55e638ab71",
+    "wof:geomhash":"75d9f868dec3b5ffcdc53dca17d26098",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -660,7 +661,7 @@
         }
     ],
     "wof:id":1108693653,
-    "wof:lastmodified":1566708819,
+    "wof:lastmodified":1695886114,
     "wof:name":"Buenos Aires",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/110/869/365/5/1108693655.geojson
+++ b/data/110/869/365/5/1108693655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014154,
-    "geom:area_square_m":172481480.043934,
+    "geom:area_square_m":172480390.423843,
     "geom:bbox":"-84.029886,9.61084,-83.790469,9.854015",
     "geom:latitude":9.747254,
     "geom:longitude":-83.93018,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CR.CA.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414951,
-    "wof:geomhash":"4bb89ecdb45c9031102b50f5cb99cb86",
+    "wof:geomhash":"6baeb55193a063b414f28fe5381b79fb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108693655,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886535,
     "wof:name":"El Guarco",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/110/869/365/7/1108693657.geojson
+++ b/data/110/869/365/7/1108693657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00264,
-    "geom:area_square_m":32156309.536547,
+    "geom:area_square_m":32156418.220145,
     "geom:bbox":"-84.078538,9.938433,-83.887196,9.975742",
     "geom:latitude":9.958383,
     "geom:longitude":-83.988345,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"CR.SJ.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414957,
-    "wof:geomhash":"b87bbfbed4c0e61201e17fcd33b9bff2",
+    "wof:geomhash":"3328af152380b91ff484e071cd7da296",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108693657,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886536,
     "wof:name":"Goicoechea",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/110/869/365/9/1108693659.geojson
+++ b/data/110/869/365/9/1108693659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010088,
-    "geom:area_square_m":122963118.627137,
+    "geom:area_square_m":122963114.555303,
     "geom:bbox":"-84.154168,9.636764,-83.970935,9.751188",
     "geom:latitude":9.69544,
     "geom:longitude":-84.070627,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"CR.SJ.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414968,
-    "wof:geomhash":"e70f635c52ef2eec8efdcce3beed2a33",
+    "wof:geomhash":"2713cc547bb7ce1dbdaf3ba84a9f59bd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108693659,
-    "wof:lastmodified":1627522027,
+    "wof:lastmodified":1695886538,
     "wof:name":"Leon Cortes",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/110/869/366/1/1108693661.geojson
+++ b/data/110/869/366/1/1108693661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046877,
-    "geom:area_square_m":570982218.15623,
+    "geom:area_square_m":570982310.299957,
     "geom:bbox":"-85.457531,9.727134,-85.149916,10.077206",
     "geom:latitude":9.913578,
     "geom:longitude":-85.280642,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CR.GU.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414978,
-    "wof:geomhash":"e9b108e58639724c00dfd66fffffc792",
+    "wof:geomhash":"c6aeefc32b79bc3f09e8dae86a347d4d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108693661,
-    "wof:lastmodified":1627522028,
+    "wof:lastmodified":1695886540,
     "wof:name":"Nandayure",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/110/869/366/3/1108693663.geojson
+++ b/data/110/869/366/3/1108693663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150127,
-    "geom:area_square_m":1828699175.502768,
+    "geom:area_square_m":1828699175.50262,
     "geom:bbox":"-87.094540821,5.49857041365,-84.6618183321,10.3373268013",
     "geom:latitude":9.888606,
     "geom:longitude":-85.019475,
@@ -159,9 +159,10 @@
     "wof:concordances":{
         "hasc:id":"CR.PU.PU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414991,
-    "wof:geomhash":"ed21aa4fb81aedabce9209c710dbb9c3",
+    "wof:geomhash":"61878600d589ab2f58348027ae1d9df9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108693663,
-    "wof:lastmodified":1566708820,
+    "wof:lastmodified":1695886114,
     "wof:name":"Puntarenas",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/110/869/366/7/1108693667.geojson
+++ b/data/110/869/366/7/1108693667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0022,
-    "geom:area_square_m":26784230.051967,
+    "geom:area_square_m":26784230.051972,
     "geom:bbox":"-84.0760386447,9.99649535237,-84.0101386216,10.0631252862",
     "geom:latitude":10.027835,
     "geom:longitude":-84.040323,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"CR.HE.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474414995,
-    "wof:geomhash":"a7f50a251befc0386d3f633f8bc509d4",
+    "wof:geomhash":"c80a1586215b11500c79dbfc2dd0ff9f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108693667,
-    "wof:lastmodified":1566708819,
+    "wof:lastmodified":1695886114,
     "wof:name":"San Isidro",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/110/869/366/9/1108693669.geojson
+++ b/data/110/869/366/9/1108693669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108865,
-    "geom:area_square_m":1324687038.507051,
+    "geom:area_square_m":1324686939.46,
     "geom:bbox":"-85.875509,9.982532,-85.406034,10.488499",
     "geom:latitude":10.242868,
     "geom:longitude":-85.685253,
@@ -219,9 +219,10 @@
     "wof:concordances":{
         "hasc:id":"CR.GU.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474415006,
-    "wof:geomhash":"29e223574196f4999f87d15ad8acc8cc",
+    "wof:geomhash":"71fa15f5cdf101980475c1add9770839",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":1108693669,
-    "wof:lastmodified":1636505092,
+    "wof:lastmodified":1695886170,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/110/869/367/1/1108693671.geojson
+++ b/data/110/869/367/1/1108693671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012963,
-    "geom:area_square_m":157748631.150983,
+    "geom:area_square_m":157748569.969416,
     "geom:bbox":"-84.51836,10.167054,-84.315016,10.270422",
     "geom:latitude":10.219271,
     "geom:longitude":-84.413883,
@@ -106,9 +106,10 @@
         "hasc:id":"CR.AL.AR",
         "wd:id":"Q975960"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1474415021,
-    "wof:geomhash":"bc6b518c06b536f0280291dfde0937ba",
+    "wof:geomhash":"2210164b87f8971b5d71706d77d04a5f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108693671,
-    "wof:lastmodified":1690868449,
+    "wof:lastmodified":1695886116,
     "wof:name":"Zarcero",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/167/827/421167827.geojson
+++ b/data/421/167/827/421167827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02818,
-    "geom:area_square_m":343430424.82351,
+    "geom:area_square_m":343430424.823614,
     "geom:bbox":"-84.3416931548,9.6225057791,-84.1320879242,9.86163260077",
     "geom:latitude":9.740737,
     "geom:longitude":-84.231621,
@@ -148,12 +148,13 @@
         "hasc:id":"CR.SJ.AC",
         "qs_pg:id":421488
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008744,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"98255a54faa9c7c6a0982ab131bf9275",
+    "wof:geomhash":"52fe59061420614953625828aec62b1b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":421167827,
-    "wof:lastmodified":1582381941,
+    "wof:lastmodified":1695886123,
     "wof:name":"Acosta",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/167/829/421167829.geojson
+++ b/data/421/167/829/421167829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013896,
-    "geom:area_square_m":169342410.390771,
+    "geom:area_square_m":169342410.390919,
     "geom:bbox":"-84.2253710098,9.61733518003,-84.0606246643,9.87535870878",
     "geom:latitude":9.744352,
     "geom:longitude":-84.137613,
@@ -118,12 +118,13 @@
         "hasc:id":"CR.SJ.AS",
         "qs_pg:id":421489
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008745,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"689e493f823709c1c3a9f35a67008b55",
+    "wof:geomhash":"d729e9a219e9d73cdca40e79024c933e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421167829,
-    "wof:lastmodified":1582381941,
+    "wof:lastmodified":1695886123,
     "wof:name":"Aserri",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/167/885/421167885.geojson
+++ b/data/421/167/885/421167885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084419,
-    "geom:area_square_m":1027278563.718608,
+    "geom:area_square_m":1027278310.521065,
     "geom:bbox":"-84.794072,9.979621,-84.414455,10.457231",
     "geom:latitude":10.224967,
     "geom:longitude":-84.596609,
@@ -179,12 +179,13 @@
         "qs_pg:id":467306,
         "wd:id":"Q347769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008746,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"138f177e8514e5cef27739678001b178",
+    "wof:geomhash":"c83140573848188d5c820279c25126ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":421167885,
-    "wof:lastmodified":1690868454,
+    "wof:lastmodified":1695886171,
     "wof:name":"San Ramon",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/169/971/421169971.geojson
+++ b/data/421/169/971/421169971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010291,
-    "geom:area_square_m":125329982.271623,
+    "geom:area_square_m":125330032.567895,
     "geom:bbox":"-84.667757,9.906922,-84.451925,10.01494",
     "geom:latitude":9.959798,
     "geom:longitude":-84.547406,
@@ -170,12 +170,13 @@
         "qs_pg:id":772731,
         "wd:id":"Q3029861"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008831,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"39ef84e2a71c717a343e84d3a97c1d75",
+    "wof:geomhash":"c20a12cada14f1de3225e915beb33342",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421169971,
-    "wof:lastmodified":1690868456,
+    "wof:lastmodified":1695886172,
     "wof:name":"San Mateo",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/169/973/421169973.geojson
+++ b/data/421/169/973/421169973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110266,
-    "geom:area_square_m":1338931295.111973,
+    "geom:area_square_m":1338930842.192319,
     "geom:bbox":"-84.897612,10.629432,-84.451475,11.084494",
     "geom:latitude":10.884147,
     "geom:longitude":-84.666104,
@@ -125,12 +125,13 @@
         "qs_pg:id":772732,
         "wd:id":"Q1757578"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008831,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37c929000b882b26a2a49293a682085f",
+    "wof:geomhash":"47d1851d1cc1e7501250883418a7d77c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421169973,
-    "wof:lastmodified":1690868457,
+    "wof:lastmodified":1695886123,
     "wof:name":"Los Chiles",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/169/975/421169975.geojson
+++ b/data/421/169/975/421169975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001284,
-    "geom:area_square_m":15643503.221888,
+    "geom:area_square_m":15643450.362955,
     "geom:bbox":"-84.065917,9.922414,-83.956547,9.95776",
     "geom:latitude":9.94198,
     "geom:longitude":-84.018786,
@@ -131,12 +131,13 @@
         "qs_pg:id":772733,
         "wd:id":"Q2569193"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008831,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1b4b4c35670603ca4e55b703750cc29",
+    "wof:geomhash":"c457261b36ee12f3be2ee242f4f6e440",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421169975,
-    "wof:lastmodified":1690868457,
+    "wof:lastmodified":1695886124,
     "wof:name":"Montes De Oca",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/169/977/421169977.geojson
+++ b/data/421/169/977/421169977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023869,
-    "geom:area_square_m":291020003.20217,
+    "geom:area_square_m":291020003.201947,
     "geom:bbox":"-84.158727336,9.44611598604,-83.9723068217,9.71856865936",
     "geom:latitude":9.587117,
     "geom:longitude":-84.044958,
@@ -95,12 +95,13 @@
         "hasc:id":"CR.SJ.TA",
         "qs_pg:id":772734
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008831,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9af9436eb9e95318b0c004b0822cbd53",
+    "wof:geomhash":"9131eb31b517d7a312e0d4eae7bcba32",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421169977,
-    "wof:lastmodified":1582381942,
+    "wof:lastmodified":1695886124,
     "wof:name":"Tarrazu",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/170/047/421170047.geojson
+++ b/data/421/170/047/421170047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020689,
-    "geom:area_square_m":252083274.939313,
+    "geom:area_square_m":252083638.938599,
     "geom:bbox":"-83.785554,9.689691,-83.59913,9.948773",
     "geom:latitude":9.806807,
     "geom:longitude":-83.702699,
@@ -102,12 +102,13 @@
         "qs_pg:id":1264092,
         "wd:id":"Q3808449"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008835,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"939f2bb9031eecba509ba89b1c32f948",
+    "wof:geomhash":"90986e7275cdd6899bdfd599c58fdb95",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":421170047,
-    "wof:lastmodified":1627522027,
+    "wof:lastmodified":1695886536,
     "wof:name":"Jimenez",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/170/049/421170049.geojson
+++ b/data/421/170/049/421170049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114638,
-    "geom:area_square_m":1391463130.787227,
+    "geom:area_square_m":1391462987.691769,
     "geom:bbox":"-85.950251,10.797038,-85.229091,11.219758",
     "geom:latitude":11.002254,
     "geom:longitude":-85.579663,
@@ -178,12 +178,13 @@
         "qs_pg:id":1264093,
         "wd:id":"Q3820791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008835,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b5c1d1d569e411d5003e42e107aa969d",
+    "wof:geomhash":"d8e768d01a99200b85f905035270559e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":421170049,
-    "wof:lastmodified":1690868479,
+    "wof:lastmodified":1695886173,
     "wof:name":"La Cruz",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/170/251/421170251.geojson
+++ b/data/421/170/251/421170251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055167,
-    "geom:area_square_m":670797652.677808,
+    "geom:area_square_m":670797346.20205,
     "geom:bbox":"-85.045779,10.320545,-84.766238,10.652305",
     "geom:latitude":10.468628,
     "geom:longitude":-84.913672,
@@ -122,12 +122,13 @@
         "qs_pg:id":1289863,
         "wd:id":"Q7802056"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008845,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac293e4ef77c738f9ceba0dfdd8567ec",
+    "wof:geomhash":"355fd66a07ac120d9b0bbb26a35161b6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421170251,
-    "wof:lastmodified":1690868479,
+    "wof:lastmodified":1695886538,
     "wof:name":"Tilaran",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/170/303/421170303.geojson
+++ b/data/421/170/303/421170303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063618,
-    "geom:area_square_m":774661261.6021,
+    "geom:area_square_m":774661140.945798,
     "geom:bbox":"-83.467849,9.797704,-83.150845,10.223784",
     "geom:latitude":10.016212,
     "geom:longitude":-83.292264,
@@ -113,12 +113,13 @@
         "qs_pg:id":237823,
         "wd:id":"Q3851882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008847,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3be6d312b866e4f339bdc5a1ab3ecb3",
+    "wof:geomhash":"d22b3bdf7f6b1f1ad4ffb66c9e4dc5e9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421170303,
-    "wof:lastmodified":1690868480,
+    "wof:lastmodified":1695886536,
     "wof:name":"Matina",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/171/355/421171355.geojson
+++ b/data/421/171/355/421171355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198973,
-    "geom:area_square_m":2419400218.415359,
+    "geom:area_square_m":2419400218.414364,
     "geom:bbox":"-83.9469629663,10.0629758882,-83.3433523811,10.9390760398",
     "geom:latitude":10.465129,
     "geom:longitude":-83.678757,
@@ -121,12 +121,13 @@
         "hasc:id":"CR.LI.PO",
         "qs_pg:id":1242711
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008890,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7210ae208ba6a67182ed50aa9a77a66d",
+    "wof:geomhash":"3e5cffb50cc3e539e3ca135d229a02cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421171355,
-    "wof:lastmodified":1582381953,
+    "wof:lastmodified":1695886131,
     "wof:name":"Pococi",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/171/707/421171707.geojson
+++ b/data/421/171/707/421171707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00653,
-    "geom:area_square_m":79537574.811942,
+    "geom:area_square_m":79537574.811828,
     "geom:bbox":"-83.8426942536,9.87112431744,-83.7604681547,10.0168859043",
     "geom:latitude":9.937477,
     "geom:longitude":-83.804829,
@@ -138,12 +138,13 @@
         "hasc:id":"CR.CA.AL",
         "qs_pg:id":1264062
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aefa2dbd56036ebd893e72c135e70307",
+    "wof:geomhash":"cd3363291df6534185088121314b2423",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421171707,
-    "wof:lastmodified":1582381953,
+    "wof:lastmodified":1695886132,
     "wof:name":"Alvarado",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/171/711/421171711.geojson
+++ b/data/421/171/711/421171711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105112,
-    "geom:area_square_m":1277840969.326478,
+    "geom:area_square_m":1277840725.779439,
     "geom:bbox":"-85.433604,10.251864,-85.061292,10.775948",
     "geom:latitude":10.530698,
     "geom:longitude":-85.260535,
@@ -125,12 +125,13 @@
         "qs_pg:id":1264078,
         "wd:id":"Q1401294"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"043e15bb27552a5d192b925a8db9b3e7",
+    "wof:geomhash":"b6f227c75b3ec87c215fe5392a8e4e98",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421171711,
-    "wof:lastmodified":1690868488,
+    "wof:lastmodified":1695886132,
     "wof:name":"Bagaces",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/171/715/421171715.geojson
+++ b/data/421/171/715/421171715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077516,
-    "geom:area_square_m":946940650.621362,
+    "geom:area_square_m":946940865.597188,
     "geom:bbox":"-83.106512,8.690453,-82.712114,9.096602",
     "geom:latitude":8.908406,
     "geom:longitude":-82.922714,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.PU.CB",
         "qs_pg:id":1264090
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5200bdd1891702ad6dd479a8c2f3f01e",
+    "wof:geomhash":"1953c3762b2b605d7a060f0c8e372a7f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421171715,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886534,
     "wof:name":"Coto Brus",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/171/717/421171717.geojson
+++ b/data/421/171/717/421171717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021616,
-    "geom:area_square_m":263241230.796934,
+    "geom:area_square_m":263241093.55924,
     "geom:bbox":"-85.496088,9.850222,-85.323206,10.100723",
     "geom:latitude":9.985961,
     "geom:longitude":-85.413998,
@@ -109,12 +109,13 @@
         "qs_pg:id":1264091,
         "wd:id":"Q1706252"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b73bc036caf5fdb4bd5f43885d3aeb92",
+    "wof:geomhash":"0dd29ddd4d09db07024a81bd942fb29c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":421171717,
-    "wof:lastmodified":1690868488,
+    "wof:lastmodified":1695886537,
     "wof:name":"Hojancha",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/172/003/421172003.geojson
+++ b/data/421/172/003/421172003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130925,
-    "geom:area_square_m":1595177153.601918,
+    "geom:area_square_m":1595177313.794811,
     "geom:bbox":"-83.819252,9.484012,-83.311907,10.083643",
     "geom:latitude":9.821754,
     "geom:longitude":-83.549232,
@@ -152,12 +152,13 @@
         "qs_pg:id":1289864,
         "wd:id":"Q2625953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008915,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9fb2de5b5834b3946180892615099abe",
+    "wof:geomhash":"0737b50ca432734af7ef4952eaecfaf3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421172003,
-    "wof:lastmodified":1690868466,
+    "wof:lastmodified":1695886128,
     "wof:name":"Turrialba",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/172/005/421172005.geojson
+++ b/data/421/172/005/421172005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03426,
-    "geom:area_square_m":417497347.054614,
+    "geom:area_square_m":417497415.843221,
     "geom:bbox":"-84.592696,9.56959,-84.403502,9.925489",
     "geom:latitude":9.760047,
     "geom:longitude":-84.5067,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.SJ.TU",
         "qs_pg:id":1289866
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008915,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"706c5b24ec9ab9ac16067b19c1646ff2",
+    "wof:geomhash":"dc9060a069bca0fe11b709ac3cbb6d81",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421172005,
-    "wof:lastmodified":1627522028,
+    "wof:lastmodified":1695886538,
     "wof:name":"Turrubares",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/172/007/421172007.geojson
+++ b/data/421/172/007/421172007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131612,
-    "geom:area_square_m":1598143663.990753,
+    "geom:area_square_m":1598143351.739934,
     "geom:bbox":"-85.449169,10.670787,-84.880578,11.06557",
     "geom:latitude":10.881829,
     "geom:longitude":-85.14929,
@@ -134,12 +134,13 @@
         "qs_pg:id":1289867,
         "wd:id":"Q691346"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459008915,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8c6af43b4a2dbab817a069b6497d9ec",
+    "wof:geomhash":"f05c10a5c91f7c4864c9e163388440e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421172007,
-    "wof:lastmodified":1690868466,
+    "wof:lastmodified":1695886128,
     "wof:name":"Upala",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/175/393/421175393.geojson
+++ b/data/421/175/393/421175393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010493,
-    "geom:area_square_m":127736989.592734,
+    "geom:area_square_m":127737150.040438,
     "geom:bbox":"-84.443943,10.01804,-84.333081,10.193454",
     "geom:latitude":10.114133,
     "geom:longitude":-84.386458,
@@ -140,12 +140,13 @@
         "qs_pg:id":368960,
         "wd:id":"Q1757000"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"84bdb8e3c9c5dded6babdad091e46530",
+    "wof:geomhash":"60de9a4d34b825f8d1c7981023e9ea52",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421175393,
-    "wof:lastmodified":1690868470,
+    "wof:lastmodified":1695886128,
     "wof:name":"Naranjo",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/175/395/421175395.geojson
+++ b/data/421/175/395/421175395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10965,
-    "geom:area_square_m":1334771350.644295,
+    "geom:area_square_m":1334771415.787894,
     "geom:bbox":"-85.696765,9.860097,-85.189269,10.347095",
     "geom:latitude":10.115196,
     "geom:longitude":-85.447434,
@@ -155,12 +155,13 @@
         "qs_pg:id":368961,
         "wd:id":"Q2486629"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f547c3358b45acd58349c3325b1a966",
+    "wof:geomhash":"94abe7fa6169cf852b30f8dc457855bc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421175395,
-    "wof:lastmodified":1690868470,
+    "wof:lastmodified":1695886129,
     "wof:name":"Nicoya",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/175/397/421175397.geojson
+++ b/data/421/175/397/421175397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016713,
-    "geom:area_square_m":203518890.289619,
+    "geom:area_square_m":203518890.289608,
     "geom:bbox":"-83.9469629663,9.84780205404,-83.8005201135,10.1473013683",
     "geom:latitude":10.007701,
     "geom:longitude":-83.865866,
@@ -97,12 +97,13 @@
         "hasc:id":"CR.CA.OR",
         "qs_pg:id":368962
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2e7214c1928f2fe5360fbeb3d1d00296",
+    "wof:geomhash":"f5f04d210ab4a235d7fef8be9e6940ba",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421175397,
-    "wof:lastmodified":1582381947,
+    "wof:lastmodified":1695886128,
     "wof:name":"Oreamuno",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/175/401/421175401.geojson
+++ b/data/421/175/401/421175401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045782,
-    "geom:area_square_m":557943550.121971,
+    "geom:area_square_m":557943417.375156,
     "geom:bbox":"-84.491557,9.556494,-84.252041,9.91153",
     "geom:latitude":9.741989,
     "geom:longitude":-84.387042,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.SJ.PU",
         "qs_pg:id":368975
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ccf8f0d47d71caf220226a2ac6d42034",
+    "wof:geomhash":"b9daf3a2fef562ae414122f33d46ac4b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421175401,
-    "wof:lastmodified":1627522028,
+    "wof:lastmodified":1695886538,
     "wof:name":"Puriscal",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/175/407/421175407.geojson
+++ b/data/421/175/407/421175407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011283,
-    "geom:area_square_m":137312464.100893,
+    "geom:area_square_m":137312521.142496,
     "geom:bbox":"-84.362149,10.048149,-84.226587,10.276312",
     "geom:latitude":10.189871,
     "geom:longitude":-84.301083,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.AL.VV",
         "qs_pg:id":368986
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81f89d603133b5116d04af02b6072b8b",
+    "wof:geomhash":"eb554f22a9059390af374ea4173424fd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421175407,
-    "wof:lastmodified":1627522029,
+    "wof:lastmodified":1695886541,
     "wof:name":"Valverde Vega",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/175/409/421175409.geojson
+++ b/data/421/175/409/421175409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018448,
-    "geom:area_square_m":224611432.883348,
+    "geom:area_square_m":224611432.883395,
     "geom:bbox":"-84.0349992203,9.96438247489,-83.8585833933,10.1900422034",
     "geom:latitude":10.043598,
     "geom:longitude":-83.948307,
@@ -118,12 +118,13 @@
         "qs_pg:id":368987,
         "wd:id":"Q1935116"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d99b59d21aeb84fecb951a0f15fe341",
+    "wof:geomhash":"4ce28d84e8deaa7cfa00256882c1c76e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421175409,
-    "wof:lastmodified":1582381948,
+    "wof:lastmodified":1695886129,
     "wof:name":"Vazquez De Coronado",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/179/213/421179213.geojson
+++ b/data/421/179/213/421179213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013501,
-    "geom:area_square_m":164467498.784104,
+    "geom:area_square_m":164467498.784108,
     "geom:bbox":"-84.4142889763,9.80835326296,-84.1458937396,9.93620576483",
     "geom:latitude":9.884184,
     "geom:longitude":-84.269844,
@@ -196,12 +196,13 @@
         "hasc:id":"CR.SJ.MR",
         "qs_pg:id":368945
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009208,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0eebfe64ee6a0149367ee9309c2151c",
+    "wof:geomhash":"fbe745029089150b61472c0162f24228",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":421179213,
-    "wof:lastmodified":1582381952,
+    "wof:lastmodified":1695886131,
     "wof:name":"Mora",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/180/915/421180915.geojson
+++ b/data/421/180/915/421180915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000679,
-    "geom:area_square_m":8273366.946191,
+    "geom:area_square_m":8273425.564608,
     "geom:bbox":"-84.113887,9.971305,-84.074021,10.01261",
     "geom:latitude":9.994936,
     "geom:longitude":-84.094592,
@@ -182,12 +182,13 @@
         "qs_pg:id":467302,
         "wd:id":"Q295411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009275,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7af4af672bd0f8d1c9f45da480bd5f0c",
+    "wof:geomhash":"4b5653dddb671cf46850fd255823b7af",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":421180915,
-    "wof:lastmodified":1690868462,
+    "wof:lastmodified":1695886172,
     "wof:name":"San Pablo",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/180/917/421180917.geojson
+++ b/data/421/180/917/421180917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003976,
-    "geom:area_square_m":48406862.40764,
+    "geom:area_square_m":48406814.803478,
     "geom:bbox":"-84.119656,9.998605,-84.044469,10.120828",
     "geom:latitude":10.048199,
     "geom:longitude":-84.078998,
@@ -185,12 +185,13 @@
         "qs_pg:id":467303,
         "wd:id":"Q293268"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009275,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd7bcadaf09b92e9423cd171e58e6199",
+    "wof:geomhash":"92a814dc779cdf205bdb5fcdce7ada11",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421180917,
-    "wof:lastmodified":1690868463,
+    "wof:lastmodified":1695886172,
     "wof:name":"San Rafael",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/180/919/421180919.geojson
+++ b/data/421/180/919/421180919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005052,
-    "geom:area_square_m":61535602.724131,
+    "geom:area_square_m":61535529.91787,
     "geom:bbox":"-84.244065,9.863306,-84.147039,9.973329",
     "geom:latitude":9.920169,
     "geom:longitude":-84.188947,
@@ -223,12 +223,13 @@
         "hasc:id":"CR.SJ.SA",
         "qs_pg:id":467307
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009276,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b91f3c531dce5697588f50d71889eece",
+    "wof:geomhash":"594038a31c38f43554ee1a9b4bcbb532",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -238,7 +239,7 @@
         }
     ],
     "wof:id":421180919,
-    "wof:lastmodified":1636505106,
+    "wof:lastmodified":1695886172,
     "wof:name":"Santa Ana",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/182/071/421182071.geojson
+++ b/data/421/182/071/421182071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03957,
-    "geom:area_square_m":482498514.197662,
+    "geom:area_square_m":482498288.982376,
     "geom:bbox":"-84.555584,9.446499,-84.130503,9.649858",
     "geom:latitude":9.561996,
     "geom:longitude":-84.317029,
@@ -113,12 +113,13 @@
         "qs_pg:id":890667,
         "wd:id":"Q7139824"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009317,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53620467d30ec44e1df2a0587949e9ab",
+    "wof:geomhash":"018a02f90c9679bf34acd59e2bac8413",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421182071,
-    "wof:lastmodified":1690868485,
+    "wof:lastmodified":1695886539,
     "wof:name":"Parrita",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/182/141/421182141.geojson
+++ b/data/421/182/141/421182141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15635,
-    "geom:area_square_m":1907555322.784477,
+    "geom:area_square_m":1907555422.443378,
     "geom:bbox":"-84.001749,9.074913,-83.429295,9.598456",
     "geom:latitude":9.360862,
     "geom:longitude":-83.67391,
@@ -95,12 +95,13 @@
         "hasc:id":"CR.SJ.PZ",
         "qs_pg:id":890668
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009320,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f4a6726f2ae03f3d9a2c1fcaf50b1242",
+    "wof:geomhash":"5b5988fc48017c9d2db73d45bddf8bb7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421182141,
-    "wof:lastmodified":1627522028,
+    "wof:lastmodified":1695886539,
     "wof:name":"Perez Zeledon",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/182/145/421182145.geojson
+++ b/data/421/182/145/421182145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039283,
-    "geom:area_square_m":478774735.313245,
+    "geom:area_square_m":478774516.651564,
     "geom:bbox":"-83.89476,9.551109,-83.627033,9.907668",
     "geom:latitude":9.716483,
     "geom:longitude":-83.765399,
@@ -149,12 +149,13 @@
         "qs_pg:id":890666,
         "wd:id":"Q1579868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009320,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3f0b08c5dcd10e9c5b83c0d50d618935",
+    "wof:geomhash":"c39483660af45919332f047440adfb93",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421182145,
-    "wof:lastmodified":1690868485,
+    "wof:lastmodified":1695886131,
     "wof:name":"Paraiso",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/183/455/421183455.geojson
+++ b/data/421/183/455/421183455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023354,
-    "geom:area_square_m":284261251.359275,
+    "geom:area_square_m":284261239.949898,
     "geom:bbox":"-84.164709,9.959616,-83.913612,10.298438",
     "geom:latitude":10.149613,
     "geom:longitude":-84.07464,
@@ -130,12 +130,13 @@
         "hasc:id":"CR.HE.HE",
         "qs_pg:id":978243
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009370,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1010389767b0238492f1e7a6292dbc27",
+    "wof:geomhash":"9c121c94682a4a712e8bf5c16d549fe7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421183455,
-    "wof:lastmodified":1636505116,
+    "wof:lastmodified":1695886174,
     "wof:name":"Heredia",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/183/457/421183457.geojson
+++ b/data/421/183/457/421183457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.276888,
-    "geom:area_square_m":3365448633.846973,
+    "geom:area_square_m":3365449231.071457,
     "geom:bbox":"-84.863171,10.246362,-84.161126,10.995947",
     "geom:latitude":10.589072,
     "geom:longitude":-84.435801,
@@ -200,12 +200,13 @@
         "qs_pg:id":978259,
         "wd:id":"Q251402"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009370,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a08396bc3374cbc96f2020370c713f71",
+    "wof:geomhash":"f334a31cc9f333b8ec32db27f90f0c52",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":421183457,
-    "wof:lastmodified":1690868483,
+    "wof:lastmodified":1695886174,
     "wof:name":"San Carlos",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/184/839/421184839.geojson
+++ b/data/421/184/839/421184839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03336,
-    "geom:area_square_m":406744715.984849,
+    "geom:area_square_m":406744483.073805,
     "geom:bbox":"-83.989677,9.430669,-83.757945,9.739354",
     "geom:latitude":9.587093,
     "geom:longitude":-83.913044,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.SJ.DO",
         "qs_pg:id":1119686
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009424,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9cd4f1cb898e8723109fcdc8defd330f",
+    "wof:geomhash":"eb8b56fea23092b09cacec4f126582cb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421184839,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886534,
     "wof:name":"Dota",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/185/327/421185327.geojson
+++ b/data/421/185/327/421185327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002083,
-    "geom:area_square_m":25369776.640815,
+    "geom:area_square_m":25369776.640785,
     "geom:bbox":"-84.1139628342,9.96034297484,-84.0230869991,10.0161301432",
     "geom:latitude":9.98555,
     "geom:longitude":-84.066275,
@@ -390,12 +390,13 @@
         "hasc:id":"CR.HE.SD",
         "qs_pg:id":890670
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"881e2e2f0f325aa48bf72394d7fc2e65",
+    "wof:geomhash":"511026694acb08c96b9177a4215b5d57",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -405,7 +406,7 @@
         }
     ],
     "wof:id":421185327,
-    "wof:lastmodified":1582381954,
+    "wof:lastmodified":1695886132,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/185/329/421185329.geojson
+++ b/data/421/185/329/421185329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177114,
-    "geom:area_square_m":2153378457.353833,
+    "geom:area_square_m":2153378457.354814,
     "geom:bbox":"-84.1612997406,10.1823030276,-83.70995568,10.792598658",
     "geom:latitude":10.498276,
     "geom:longitude":-83.994748,
@@ -118,12 +118,13 @@
         "hasc:id":"CR.HE.SA",
         "qs_pg:id":890671
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f00f6532ff5c19c427bd544b2c54093",
+    "wof:geomhash":"3d780796318c425fda88a424d21cd3cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421185329,
-    "wof:lastmodified":1582381955,
+    "wof:lastmodified":1695886133,
     "wof:name":"Sarapiqui",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/185/331/421185331.geojson
+++ b/data/421/185/331/421185331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07049,
-    "geom:area_square_m":858020439.541284,
+    "geom:area_square_m":858020300.94435,
     "geom:bbox":"-83.7252,9.981802,-83.269494,10.312356",
     "geom:latitude":10.137037,
     "geom:longitude":-83.479663,
@@ -128,12 +128,13 @@
         "qs_pg:id":890672,
         "wd:id":"Q3961977"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b48f25e69bb436b694708a4a496fcdfd",
+    "wof:geomhash":"e8c2fd7694c236add8702535d2d5dab8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421185331,
-    "wof:lastmodified":1690868488,
+    "wof:lastmodified":1695886132,
     "wof:name":"Siquirres",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/185/333/421185333.geojson
+++ b/data/421/185/333/421185333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231783,
-    "geom:area_square_m":2826926535.948731,
+    "geom:area_square_m":2826926535.948988,
     "geom:bbox":"-83.4890873606,9.07493244098,-82.552318988,9.76776201678",
     "geom:latitude":9.476541,
     "geom:longitude":-83.087196,
@@ -127,12 +127,13 @@
         "hasc:id":"CR.LI.TA",
         "qs_pg:id":890673
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f974e624d83ef787341996f3981c8d6e",
+    "wof:geomhash":"39a78e7dc4a535b6a194021040085c6f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421185333,
-    "wof:lastmodified":1582381954,
+    "wof:lastmodified":1695886133,
     "wof:name":"Talamanca",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/185/489/421185489.geojson
+++ b/data/421/185/489/421185489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020363,
-    "geom:area_square_m":247871410.43847,
+    "geom:area_square_m":247871472.397195,
     "geom:bbox":"-84.812055,10.008765,-84.656564,10.284366",
     "geom:latitude":10.123403,
     "geom:longitude":-84.724498,
@@ -94,12 +94,13 @@
         "hasc:id":"CR.PU.MO",
         "qs_pg:id":897117
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009444,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67e425b3d86acb518060509159880260",
+    "wof:geomhash":"cdf8ffa953476c41842ce9612417dfbf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421185489,
-    "wof:lastmodified":1627522027,
+    "wof:lastmodified":1695886537,
     "wof:name":"Montes De Oro",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/188/065/421188065.geojson
+++ b/data/421/188/065/421188065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145719,
-    "geom:area_square_m":1775689717.495697,
+    "geom:area_square_m":1775689717.495731,
     "geom:bbox":"-83.5162075235,9.4840119004,-82.8690360594,10.0664412112",
     "geom:latitude":9.772845,
     "geom:longitude":-83.15291,
@@ -133,12 +133,13 @@
         "hasc:id":"CR.LI.LI",
         "qs_pg:id":1087911
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009533,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59537e6e66dd16de5767a0d6d1183d46",
+    "wof:geomhash":"34bd82ad261c8b16bba4941635000bb7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421188065,
-    "wof:lastmodified":1582381946,
+    "wof:lastmodified":1695886126,
     "wof:name":"Limon",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/188/109/421188109.geojson
+++ b/data/421/188/109/421188109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158473,
-    "geom:area_square_m":1936211399.941209,
+    "geom:area_square_m":1936211399.943012,
     "geom:bbox":"-83.8695070091,8.50417282287,-83.1626624712,9.28062085006",
     "geom:latitude":8.850735,
     "geom:longitude":-83.5037,
@@ -160,12 +160,13 @@
         "hasc:id":"CR.PU.OS",
         "qs_pg:id":1087912
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009534,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3375539b0398e632dc775861e1ca3ae5",
+    "wof:geomhash":"ff404bab4c1ee5840eeb5bdaf76bf328",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":421188109,
-    "wof:lastmodified":1582381946,
+    "wof:lastmodified":1695886126,
     "wof:name":"Osa",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/188/115/421188115.geojson
+++ b/data/421/188/115/421188115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002847,
-    "geom:area_square_m":34678899.784523,
+    "geom:area_square_m":34678913.324857,
     "geom:bbox":"-84.185823,9.859566,-84.120777,9.972575",
     "geom:latitude":9.914695,
     "geom:longitude":-84.14524,
@@ -94,12 +94,13 @@
         "hasc:id":"CR.SJ.ES",
         "qs_pg:id":1087908
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009534,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3bdc97e61402e18a4dc9a982834bfcda",
+    "wof:geomhash":"976898f5a28028290af1daa27352177f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421188115,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886534,
     "wof:name":"Escazu",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/188/117/421188117.geojson
+++ b/data/421/188/117/421188117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017933,
-    "geom:area_square_m":218380634.562432,
+    "geom:area_square_m":218380634.5625,
     "geom:bbox":"-84.7410454978,9.86372954541,-84.5530043702,10.1278394895",
     "geom:latitude":9.989326,
     "geom:longitude":-84.6555,
@@ -106,12 +106,13 @@
         "hasc:id":"CR.PU.ES",
         "qs_pg:id":1087909
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009534,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"efc15be02a04016c0633ebb4da888640",
+    "wof:geomhash":"0db15c5f0d00390b90ae71235fbca34e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":421188117,
-    "wof:lastmodified":1582381946,
+    "wof:lastmodified":1695886127,
     "wof:name":"Esparza",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/188/119/421188119.geojson
+++ b/data/421/188/119/421188119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119125,
-    "geom:area_square_m":1447399310.185174,
+    "geom:area_square_m":1447399310.184981,
     "geom:bbox":"-85.6993382292,10.4184548306,-85.2920188884,10.9651828463",
     "geom:latitude":10.696879,
     "geom:longitude":-85.490105,
@@ -681,12 +681,13 @@
         "hasc:id":"CR.GU.LI",
         "qs_pg:id":1087910
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009534,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"904a341fb478f7f68f7616a317add470",
+    "wof:geomhash":"de3564245c19ff8ba6fc8f4c256f58aa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -696,7 +697,7 @@
         }
     ],
     "wof:id":421188119,
-    "wof:lastmodified":1582381946,
+    "wof:lastmodified":1695886127,
     "wof:name":"Liberia",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/189/139/421189139.geojson
+++ b/data/421/189/139/421189139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023016,
-    "geom:area_square_m":280429773.240015,
+    "geom:area_square_m":280430899.230759,
     "geom:bbox":"-84.088529,9.603838,-83.765321,9.971182",
     "geom:latitude":9.815264,
     "geom:longitude":-83.921036,
@@ -190,12 +190,13 @@
         "hasc:id":"CR.CA.CA",
         "qs_pg:id":1110214
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009611,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6187a2dac293379de878147ce2b3d29b",
+    "wof:geomhash":"de1df98389d34e960384898ad6ecd235",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":421189139,
-    "wof:lastmodified":1636505109,
+    "wof:lastmodified":1695886173,
     "wof:name":"Cartago",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/421/189/149/421189149.geojson
+++ b/data/421/189/149/421189149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051269,
-    "geom:area_square_m":626912704.504193,
+    "geom:area_square_m":626912339.309609,
     "geom:bbox":"-83.057239,8.34195,-82.822255,8.733774",
     "geom:latitude":8.549269,
     "geom:longitude":-82.934257,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.PU.CO",
         "qs_pg:id":1110220
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009611,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6e0c93c5925f28f82f73ebbcf3217a4d",
+    "wof:geomhash":"24840d1ee8e88005b3f5164778269f7e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421189149,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886535,
     "wof:name":"Corredores",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/190/515/421190515.geojson
+++ b/data/421/190/515/421190515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053605,
-    "geom:area_square_m":652261364.094025,
+    "geom:area_square_m":652261554.115659,
     "geom:bbox":"-85.225659,10.109038,-84.827092,10.389386",
     "geom:latitude":10.247592,
     "geom:longitude":-85.005072,
@@ -94,12 +94,13 @@
         "hasc:id":"CR.GU.AB",
         "qs_pg:id":1119684
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009660,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9cfd7c5c56b0c147521ab1df64e1b277",
+    "wof:geomhash":"3f47efbe854ace29a7a86d9f6056646d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421190515,
-    "wof:lastmodified":1627522025,
+    "wof:lastmodified":1695886531,
     "wof:name":"Abangares",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/190/519/421190519.geojson
+++ b/data/421/190/519/421190519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009841,
-    "geom:area_square_m":119907898.305561,
+    "geom:area_square_m":119907954.370707,
     "geom:bbox":"-84.109845,9.714225,-83.94878,9.908795",
     "geom:latitude":9.814631,
     "geom:longitude":-84.045534,
@@ -122,12 +122,13 @@
         "qs_pg:id":1119685,
         "wd:id":"Q14108797"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009660,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f98a45b74c1069efd64b743635f5d187",
+    "wof:geomhash":"151593b15eaa885d7e0501a7ae48391a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421190519,
-    "wof:lastmodified":1690868471,
+    "wof:lastmodified":1695886129,
     "wof:name":"Desamparados",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/193/823/421193823.geojson
+++ b/data/421/193/823/421193823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004611,
-    "geom:area_square_m":56137981.627815,
+    "geom:area_square_m":56137984.544807,
     "geom:bbox":"-84.146044,10.009928,-84.085313,10.137054",
     "geom:latitude":10.07556,
     "geom:longitude":-84.114717,
@@ -128,12 +128,13 @@
         "qs_pg:id":421486,
         "wd:id":"Q2414905"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009784,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"693803ed9337394887c4bab5d02b8515",
+    "wof:geomhash":"88cfda3c22da45d1019959afabb96d17",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421193823,
-    "wof:lastmodified":1690868453,
+    "wof:lastmodified":1695886123,
     "wof:name":"Barva",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/194/119/421194119.geojson
+++ b/data/421/194/119/421194119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006155,
-    "geom:area_square_m":74927493.812847,
+    "geom:area_square_m":74927414.045554,
     "geom:bbox":"-84.299799,10.014249,-84.195733,10.198061",
     "geom:latitude":10.105849,
     "geom:longitude":-84.240932,
@@ -124,12 +124,13 @@
         "hasc:id":"CR.AL.PO",
         "qs_pg:id":890669
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009794,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bc0e1230be8971fbdbf65c606fac155f",
+    "wof:geomhash":"f2283ecb3500e4f661a96d079573d627",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421194119,
-    "wof:lastmodified":1627522028,
+    "wof:lastmodified":1695886540,
     "wof:name":"Poas",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/194/697/421194697.geojson
+++ b/data/421/194/697/421194697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144241,
-    "geom:area_square_m":1763722697.313577,
+    "geom:area_square_m":1763722715.381874,
     "geom:bbox":"-83.652435,8.039627,-82.886141,8.814248",
     "geom:latitude":8.554012,
     "geom:longitude":-83.242624,
@@ -185,12 +185,13 @@
         "qs_pg:id":897134,
         "wd:id":"Q949409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009816,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e5a68c4d52a76665f0e18d88a0f76318",
+    "wof:geomhash":"f9650b790ed9dfac79a052ef970ce067",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421194697,
-    "wof:lastmodified":1690868451,
+    "wof:lastmodified":1695886170,
     "wof:name":"Golfito",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/197/833/421197833.geojson
+++ b/data/421/197/833/421197833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001026,
-    "geom:area_square_m":12496314.330879,
+    "geom:area_square_m":12496289.434154,
     "geom:bbox":"-84.200032,9.965746,-84.15353,10.00559",
     "geom:latitude":9.983197,
     "geom:longitude":-84.177395,
@@ -356,12 +356,13 @@
         "qs_pg:id":421504,
         "wd:id":"Q816332"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009926,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b25360d3adb81d663ed7d9de1db34cb5",
+    "wof:geomhash":"852e7825beef7b4814f348c9547ffdc2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -371,7 +372,7 @@
         }
     ],
     "wof:id":421197833,
-    "wof:lastmodified":1636505112,
+    "wof:lastmodified":1695886173,
     "wof:name":"Belen",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/199/285/421199285.geojson
+++ b/data/421/199/285/421199285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003688,
-    "geom:area_square_m":44914795.908532,
+    "geom:area_square_m":44914842.872651,
     "geom:bbox":"-84.180334,9.899939,-84.046501,9.971992",
     "geom:latitude":9.935178,
     "geom:longitude":-84.102455,
@@ -296,12 +296,13 @@
         "qs_pg:id":467297,
         "wd:id":"Q173718"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459009984,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad584d83d6ccd95f003931e37690e984",
+    "wof:geomhash":"161c90303fd95bfead316e2b10b6b7ab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +312,7 @@
         }
     ],
     "wof:id":421199285,
-    "wof:lastmodified":1690868474,
+    "wof:lastmodified":1695886173,
     "wof:name":"San Jose",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/201/601/421201601.geojson
+++ b/data/421/201/601/421201601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04581,
-    "geom:area_square_m":558804688.342668,
+    "geom:area_square_m":558804816.683099,
     "geom:bbox":"-84.253801,9.254671,-83.84004,9.572033",
     "geom:latitude":9.423096,
     "geom:longitude":-84.052398,
@@ -185,12 +185,13 @@
         "qs_pg:id":1264075,
         "wd:id":"Q2776723"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010078,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"711f92c7acb4db640eca9adae9a942b8",
+    "wof:geomhash":"6cacdd3886357e28074e85a5b352bade",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421201601,
-    "wof:lastmodified":1690868477,
+    "wof:lastmodified":1695886130,
     "wof:name":"Aguirre",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/201/603/421201603.geojson
+++ b/data/421/201/603/421201603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032288,
-    "geom:area_square_m":393061174.082077,
+    "geom:area_square_m":393061174.082034,
     "geom:bbox":"-84.3676800908,9.91426659186,-84.1609551425,10.4136944924",
     "geom:latitude":10.094073,
     "geom:longitude":-84.225669,
@@ -204,12 +204,13 @@
         "hasc:id":"CR.AL.AL",
         "qs_pg:id":1264076
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010078,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ca934e0c00368a9a1755d99c0abac1de",
+    "wof:geomhash":"3686ad39522c5332e2542561ab3b47bb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":421201603,
-    "wof:lastmodified":1582381950,
+    "wof:lastmodified":1695886130,
     "wof:name":"Alajuela",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/201/605/421201605.geojson
+++ b/data/421/201/605/421201605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001768,
-    "geom:area_square_m":21536520.172826,
+    "geom:area_square_m":21536550.835966,
     "geom:bbox":"-84.145894,9.847564,-84.084156,9.931675",
     "geom:latitude":9.887681,
     "geom:longitude":-84.114608,
@@ -106,12 +106,13 @@
         "qs_pg:id":1264077,
         "wd:id":"Q3410901"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010078,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"15dad8155324f632ec263eb02f09f1b1",
+    "wof:geomhash":"3976e8bb62f582146ce0abf14f7eb674",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":421201605,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886535,
     "wof:name":"Alajuelita",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/201/613/421201613.geojson
+++ b/data/421/201/613/421201613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056318,
-    "geom:area_square_m":684846083.489109,
+    "geom:area_square_m":684846108.565384,
     "geom:bbox":"-85.247532,10.193061,-84.94965,10.708981",
     "geom:latitude":10.442132,
     "geom:longitude":-85.103547,
@@ -140,12 +140,13 @@
         "qs_pg:id":1264088,
         "wd:id":"Q1706524"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010078,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f1cefbc6d9e7282c502dd9b0d2882ac9",
+    "wof:geomhash":"b7d395c4f52ef10f760583bcb6d2e58c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421201613,
-    "wof:lastmodified":1690868476,
+    "wof:lastmodified":1695886130,
     "wof:name":"Canas",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/201/615/421201615.geojson
+++ b/data/421/201/615/421201615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049459,
-    "geom:area_square_m":601405627.255418,
+    "geom:area_square_m":601405627.255201,
     "geom:bbox":"-85.8121736822,10.325287023,-85.3690685556,10.6368885241",
     "geom:latitude":10.459959,
     "geom:longitude":-85.60228,
@@ -124,12 +124,13 @@
         "hasc:id":"CR.GU.CR",
         "qs_pg:id":1264089
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010078,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db13b5a0d0999987dcf998e5900e4df0",
+    "wof:geomhash":"91a00ddf1a3e45bd4cea268227aadcbb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421201615,
-    "wof:lastmodified":1582381950,
+    "wof:lastmodified":1695886131,
     "wof:name":"Carrillo",
     "wof:parent_id":85670399,
     "wof:placetype":"county",

--- a/data/421/202/071/421202071.geojson
+++ b/data/421/202/071/421202071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01043,
-    "geom:area_square_m":127020128.939224,
+    "geom:area_square_m":127020095.324917,
     "geom:bbox":"-84.468848,9.920312,-84.340812,10.03907",
     "geom:latitude":9.97532,
     "geom:longitude":-84.40437,
@@ -131,12 +131,13 @@
         "qs_pg:id":219086,
         "wd:id":"Q973817"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010104,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6efc9f59e9fa2bd60c2a8ce7a66488c",
+    "wof:geomhash":"40507677fcf4069fa75ea696f5349bd1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421202071,
-    "wof:lastmodified":1690868460,
+    "wof:lastmodified":1695886125,
     "wof:name":"Atenas",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/202/607/421202607.geojson
+++ b/data/421/202/607/421202607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00069,
-    "geom:area_square_m":8401389.312691,
+    "geom:area_square_m":8401363.159593,
     "geom:bbox":"-84.107211,9.941244,-84.055136,9.972863",
     "geom:latitude":9.95873,
     "geom:longitude":-84.081013,
@@ -135,12 +135,13 @@
         "qs_pg:id":224841,
         "wd:id":"Q426978"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010124,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc009067a1fe1828cfa631457ef06073",
+    "wof:geomhash":"e670e27ac8eb90fc41b5308a617a9e48",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421202607,
-    "wof:lastmodified":1690868461,
+    "wof:lastmodified":1695886125,
     "wof:name":"Tibas",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/202/609/421202609.geojson
+++ b/data/421/202/609/421202609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004281,
-    "geom:area_square_m":52122552.797173,
+    "geom:area_square_m":52122857.369652,
     "geom:bbox":"-84.173756,10.00559,-84.121594,10.15822",
     "geom:latitude":10.081776,
     "geom:longitude":-84.149988,
@@ -210,12 +210,13 @@
         "qs_pg:id":224851,
         "wd:id":"Q3948934"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010124,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"957d1c463d903108fe1ed49e5743e5ab",
+    "wof:geomhash":"cdab79e2f1dca34a4db97923e8b11a2e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":421202609,
-    "wof:lastmodified":1690868461,
+    "wof:lastmodified":1695886172,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/203/269/421203269.geojson
+++ b/data/421/203/269/421203269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000559,
-    "geom:area_square_m":6802344.292945,
+    "geom:area_square_m":6802328.040517,
     "geom:bbox":"-84.173756,9.990085,-84.134055,10.021542",
     "geom:latitude":10.006629,
     "geom:longitude":-84.155871,
@@ -283,12 +283,13 @@
         "hasc:id":"CR.HE.FL",
         "qs_pg:id":230565
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010145,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcdfcb6cbc5e0f6a00f1865c880216e6",
+    "wof:geomhash":"3e37c9e3b702f7af782e40106a00c389",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -298,7 +299,7 @@
         }
     ],
     "wof:id":421203269,
-    "wof:lastmodified":1636505105,
+    "wof:lastmodified":1695886172,
     "wof:name":"Flores",
     "wof:parent_id":85670375,
     "wof:placetype":"county",

--- a/data/421/203/271/421203271.geojson
+++ b/data/421/203/271/421203271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002384,
-    "geom:area_square_m":29027575.049847,
+    "geom:area_square_m":29027575.049865,
     "geom:bbox":"-84.0661129598,9.95275303601,-83.9751013675,10.066739891",
     "geom:latitude":10.010064,
     "geom:longitude":-84.018435,
@@ -327,12 +327,13 @@
         "hasc:id":"CR.SJ.MV",
         "qs_pg:id":230566
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010145,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"84d222f174977c8bdf8906fdab3efb63",
+    "wof:geomhash":"3ad070e24eadd1095db284cd6c487d86",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -342,7 +343,7 @@
         }
     ],
     "wof:id":421203271,
-    "wof:lastmodified":1582381944,
+    "wof:lastmodified":1695886125,
     "wof:name":"Moravia",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/203/755/421203755.geojson
+++ b/data/421/203/755/421203755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001326,
-    "geom:area_square_m":16152532.859834,
+    "geom:area_square_m":16152428.089568,
     "geom:bbox":"-84.052531,9.893644,-84.005137,9.939011",
     "geom:latitude":9.917482,
     "geom:longitude":-84.027857,
@@ -122,12 +122,13 @@
         "qs_pg:id":115565,
         "wd:id":"Q2569193"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1fa397057f9c8ea7a3537dd178fb2b50",
+    "wof:geomhash":"cc50c79b7806b3b1a28e32bd024c299a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421203755,
-    "wof:lastmodified":1690868459,
+    "wof:lastmodified":1695886124,
     "wof:name":"Curridabat",
     "wof:parent_id":85670391,
     "wof:placetype":"county",

--- a/data/421/203/757/421203757.geojson
+++ b/data/421/203/757/421203757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011964,
-    "geom:area_square_m":145739374.284991,
+    "geom:area_square_m":145739251.943127,
     "geom:bbox":"-84.689141,9.840065,-84.462073,9.946545",
     "geom:latitude":9.896386,
     "geom:longitude":-84.577916,
@@ -134,12 +134,13 @@
         "qs_pg:id":115566,
         "wd:id":"Q1179301"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57fbd569d0d6c64298b3725b04cfc191",
+    "wof:geomhash":"6f12f072640a9cb7389d4e6129c2dca8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421203757,
-    "wof:lastmodified":1690868459,
+    "wof:lastmodified":1695886124,
     "wof:name":"Orotina",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/203/763/421203763.geojson
+++ b/data/421/203/763/421203763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003203,
-    "geom:area_square_m":38993456.032763,
+    "geom:area_square_m":38993379.217633,
     "geom:bbox":"-84.470012,10.007372,-84.404722,10.086001",
     "geom:latitude":10.044257,
     "geom:longitude":-84.437167,
@@ -134,12 +134,13 @@
         "qs_pg:id":115577,
         "wd:id":"Q1759264"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0fbd49c8982869c3c465d3a99f8b4239",
+    "wof:geomhash":"8eaed6580e556ae50ad5ee21ee83761b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421203763,
-    "wof:lastmodified":1690868459,
+    "wof:lastmodified":1695886124,
     "wof:name":"Palmares",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/204/087/421204087.geojson
+++ b/data/421/204/087/421204087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025835,
-    "geom:area_square_m":314876222.462922,
+    "geom:area_square_m":314876204.442598,
     "geom:bbox":"-84.701269,9.537488,-84.529357,9.878808",
     "geom:latitude":9.715328,
     "geom:longitude":-84.610318,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.PU.GA",
         "qs_pg:id":237819
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010173,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"697bb1c3c75c343d901a79cb681efc84",
+    "wof:geomhash":"a8aa1488e33381a9648bd8a87dd11e59",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421204087,
-    "wof:lastmodified":1627522026,
+    "wof:lastmodified":1695886535,
     "wof:name":"Garabito",
     "wof:parent_id":85670385,
     "wof:placetype":"county",

--- a/data/421/204/089/421204089.geojson
+++ b/data/421/204/089/421204089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032854,
-    "geom:area_square_m":399706105.848868,
+    "geom:area_square_m":399706469.179788,
     "geom:bbox":"-84.362248,9.992817,-84.160927,10.577465",
     "geom:latitude":10.294348,
     "geom:longitude":-84.241657,
@@ -131,12 +131,13 @@
         "qs_pg:id":237820,
         "wd:id":"Q2079294"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010173,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b3c8108858ba52cf8c8175f251a2dea1",
+    "wof:geomhash":"3930a3941bf41caa36a3c750a01301f5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421204089,
-    "wof:lastmodified":1690868458,
+    "wof:lastmodified":1695886125,
     "wof:name":"Grecia",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/204/091/421204091.geojson
+++ b/data/421/204/091/421204091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047976,
-    "geom:area_square_m":583850467.2255,
+    "geom:area_square_m":583850210.018655,
     "geom:bbox":"-83.775329,10.038727,-83.470273,10.370578",
     "geom:latitude":10.201809,
     "geom:longitude":-83.646058,
@@ -125,12 +125,13 @@
         "qs_pg:id":237821,
         "wd:id":"Q3780110"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010173,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8aa9a0f88a097f663269210cfe48776",
+    "wof:geomhash":"3de0656db515e227640fb183733462a2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421204091,
-    "wof:lastmodified":1690868458,
+    "wof:lastmodified":1695886535,
     "wof:name":"Guacimo",
     "wof:parent_id":85670381,
     "wof:placetype":"county",

--- a/data/421/204/093/421204093.geojson
+++ b/data/421/204/093/421204093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062276,
-    "geom:area_square_m":756673714.223943,
+    "geom:area_square_m":756673610.968262,
     "geom:bbox":"-85.012659,10.555832,-84.646658,10.85232",
     "geom:latitude":10.694885,
     "geom:longitude":-84.841434,
@@ -93,12 +93,13 @@
         "hasc:id":"CR.AL.GU",
         "qs_pg:id":237822
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010173,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"31eaa9989935afc665952187d5f6dc12",
+    "wof:geomhash":"d59a9854293c27fbe105e5ee38d558f8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421204093,
-    "wof:lastmodified":1627522027,
+    "wof:lastmodified":1695886537,
     "wof:name":"Guatuso",
     "wof:parent_id":85670393,
     "wof:placetype":"county",

--- a/data/421/204/569/421204569.geojson
+++ b/data/421/204/569/421204569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003644,
-    "geom:area_square_m":44385151.850477,
+    "geom:area_square_m":44385180.238838,
     "geom:bbox":"-84.041855,9.87606,-83.948266,9.950315",
     "geom:latitude":9.91127,
     "geom:longitude":-83.987335,
@@ -221,12 +221,13 @@
         "hasc:id":"CR.CA.LU",
         "qs_pg:id":241934
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CR",
     "wof:created":1459010190,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c9f17b927b96cdb4abc92b767a120f21",
+    "wof:geomhash":"8741f20157265e8f6171f61dce1cc1e3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -236,7 +237,7 @@
         }
     ],
     "wof:id":421204569,
-    "wof:lastmodified":1636505104,
+    "wof:lastmodified":1695886172,
     "wof:name":"La Union",
     "wof:parent_id":85670371,
     "wof:placetype":"county",

--- a/data/856/324/87/85632487.geojson
+++ b/data/856/324/87/85632487.geojson
@@ -1145,6 +1145,7 @@
         "hasc:id":"CR",
         "icao:code":"TI",
         "ioc:id":"CRC",
+        "iso:code":"CR",
         "itu:id":"CTR",
         "loc:id":"n79070075",
         "m49:code":"188",
@@ -1159,6 +1160,7 @@
         "wk:page":"Costa Rica",
         "wmo:id":"CS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:country_alpha3":"CRI",
     "wof:geom_alt":[
@@ -1180,7 +1182,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639572,
+    "wof:lastmodified":1695881231,
     "wof:name":"Costa Rica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/703/71/85670371.geojson
+++ b/data/856/703/71/85670371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254953,
-    "geom:area_square_m":3106388034.090824,
+    "geom:area_square_m":3106387826.002534,
     "geom:bbox":"-84.088529,9.484012,-83.311907,10.147301",
     "geom:latitude":9.816033,
     "geom:longitude":-83.68327,
@@ -290,17 +290,19 @@
         "gn:id":3624368,
         "gp:id":2345083,
         "hasc:id":"CR.CA",
+        "iso:code":"CR-C",
         "iso:id":"CR-C",
         "qs_pg:id":891518,
         "unlc:id":"CR-C",
         "wd:id":"Q502181",
         "wk:page":"Cartago Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89bc43c5f1ae2b4ed0118abf3b1cbf7d",
+    "wof:geomhash":"3df23cff2c52c4ceee8909654351b070",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868448,
+    "wof:lastmodified":1695884966,
     "wof:name":"Cartago",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/75/85670375.geojson
+++ b/data/856/703/75/85670375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.219883,
-    "geom:area_square_m":2674033137.991403,
+    "geom:area_square_m":2674032863.027678,
     "geom:bbox":"-84.200032,9.959616,-83.709956,10.792599",
     "geom:latitude":10.42136,
     "geom:longitude":-84.012999,
@@ -306,17 +306,19 @@
         "gn:id":3623484,
         "gp:id":2345085,
         "hasc:id":"CR.HE",
+        "iso:code":"CR-H",
         "iso:id":"CR-H",
         "qs_pg:id":891519,
         "unlc:id":"CR-H",
         "wd:id":"Q502192",
         "wk:page":"Heredia Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d28185bb5db6eb1a2123ea6ddab509a4",
+    "wof:geomhash":"efb51717abf7d3067d08e920d93cecf7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868444,
+    "wof:lastmodified":1695885132,
     "wof:name":"Heredia",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/81/85670381.geojson
+++ b/data/856/703/81/85670381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.758559,
-    "geom:area_square_m":9238548663.525333,
+    "geom:area_square_m":9238547952.338192,
     "geom:bbox":"-83.946963,9.074932,-82.552319,10.939076",
     "geom:latitude":9.94528,
     "geom:longitude":-83.344003,
@@ -289,17 +289,19 @@
         "gn:id":3623064,
         "gp:id":2345086,
         "hasc:id":"CR.LI",
+        "iso:code":"CR-L",
         "iso:id":"CR-L",
         "qs_pg:id":569320,
         "unlc:id":"CR-L",
         "wd:id":"Q642644",
         "wk:page":"Lim\u00f3n Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"86b91a389f1add5e75d27363db587233",
+    "wof:geomhash":"096413f5dc8bd9a00b7cafe7365d3820",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868444,
+    "wof:lastmodified":1695884607,
     "wof:name":"Lim\u00f3n",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/85/85670385.geojson
+++ b/data/856/703/85/85670385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.927155,
-    "geom:area_square_m":11318132569.441952,
+    "geom:area_square_m":11318132360.18191,
     "geom:bbox":"-87.094541,5.49857,-82.712114,10.337327",
     "geom:latitude":9.147961,
     "geom:longitude":-83.716681,
@@ -326,17 +326,19 @@
         "gn:id":3622226,
         "gp:id":2345087,
         "hasc:id":"CR.PU",
+        "iso:code":"CR-P",
         "iso:id":"CR-P",
         "qs_pg:id":1117340,
         "unlc:id":"CR-P",
         "wd:id":"Q502170",
         "wk:page":"Puntarenas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2bbfb93dbfe2895ffceceb857a06e860",
+    "wof:geomhash":"e91d04277ed0652f68608587f7062869",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -351,7 +353,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868447,
+    "wof:lastmodified":1695884964,
     "wof:name":"Puntarenas",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/91/85670391.geojson
+++ b/data/856/703/91/85670391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.409255,
-    "geom:area_square_m":4989530851.286741,
+    "geom:area_square_m":4989530944.085212,
     "geom:bbox":"-84.592696,9.074913,-83.429295,10.190042",
     "geom:latitude":9.605407,
     "geom:longitude":-83.991778,
@@ -345,17 +345,19 @@
         "gn:id":3621837,
         "gp:id":2345088,
         "hasc:id":"CR.SJ",
+        "iso:code":"CR-SJ",
         "iso:id":"CR-SJ",
         "qs_pg:id":891517,
         "unlc:id":"CR-SJ",
         "wd:id":"Q647808",
         "wk:page":"San Jos\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cbe8b54570c41c4b3bcc4fdc2ac3e62",
+    "wof:geomhash":"c82a3c57a4fc05809ff9a0f6b0eac99f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -370,7 +372,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868445,
+    "wof:lastmodified":1695884501,
     "wof:name":"San Jos\u00e9",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/93/85670393.geojson
+++ b/data/856/703/93/85670393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.807384,
-    "geom:area_square_m":9814051669.612137,
+    "geom:area_square_m":9814051433.933056,
     "geom:bbox":"-85.449169,9.840065,-84.160927,11.084494",
     "geom:latitude":10.565649,
     "geom:longitude":-84.614125,
@@ -335,17 +335,19 @@
         "gn:id":3624953,
         "gp:id":2345082,
         "hasc:id":"CR.AL",
+        "iso:code":"CR-A",
         "iso:id":"CR-A",
         "qs_pg:id":913482,
         "unlc:id":"CR-A",
         "wd:id":"Q502188",
         "wk:page":"Alajuela Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf4b1390aa66ff14f771e0664e7caa0c",
+    "wof:geomhash":"cd845c4b3d616b6dbfd5bcd98173ff46",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -360,7 +362,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868444,
+    "wof:lastmodified":1695884963,
     "wof:name":"Alajuela",
     "wof:parent_id":85632487,
     "wof:placetype":"region",

--- a/data/856/703/99/85670399.geojson
+++ b/data/856/703/99/85670399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.840433,
-    "geom:area_square_m":10219695972.394241,
+    "geom:area_square_m":10219695378.297764,
     "geom:bbox":"-85.950251,9.727134,-84.766238,11.219758",
     "geom:latitude":10.446419,
     "geom:longitude":-85.391603,
@@ -323,17 +323,19 @@
         "gn:id":3623582,
         "gp:id":2345084,
         "hasc:id":"CR.GU",
+        "iso:code":"CR-G",
         "iso:id":"CR-G",
         "qs_pg:id":1117338,
         "unlc:id":"CR-G",
         "wd:id":"Q690026",
         "wk:page":"Guanacaste Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c2645ea9f949755025673c71ac45c03",
+    "wof:geomhash":"e8e739d03939cfe57ed96a7109bc6e08",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -348,7 +350,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868446,
+    "wof:lastmodified":1695884964,
     "wof:name":"Guanacaste",
     "wof:parent_id":85632487,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.