### PR TITLE
[WIP] Superseding work to deduplicate records

### DIFF
--- a/data/112/538/944/1/1125389441.geojson
+++ b/data/112/538/944/1/1125389441.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -17,7 +18,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:arg_x_preferred":[
@@ -187,12 +188,14 @@
         }
     ],
     "wof:id":1125389441,
-    "wof:lastmodified":1636505120,
+    "wof:lastmodified":1705624223,
     "wof:name":"San Pedro",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-cr",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421166603
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/911/356/9/1209113569.geojson
+++ b/data/120/911/356/9/1209113569.geojson
@@ -42,6 +42,9 @@
     "wof:concordances":{
         "gn:id":3623117
     },
+    "wof:concordances_alt":{
+        "gn:id":3622395
+    },
     "wof:country":"CR",
     "wof:geomhash":"e1b6518674e8343efd952786593e3d81",
     "wof:hierarchy":[
@@ -51,13 +54,15 @@
         }
     ],
     "wof:id":1209113569,
-    "wof:lastmodified":1566708804,
+    "wof:lastmodified":1705624225,
     "wof:name":"Pilas Blancas",
     "wof:parent_id":85632487,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1276336371
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/127/633/637/1/1276336371.geojson
+++ b/data/127/633/637/1/1276336371.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -29,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -54,12 +55,14 @@
         }
     ],
     "wof:id":1276336371,
-    "wof:lastmodified":1566708781,
+    "wof:lastmodified":1705624224,
     "wof:name":"Pilas Blancas",
     "wof:parent_id":421175395,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cr",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1209113569
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/676/879/7/1276768797.geojson
+++ b/data/127/676/879/7/1276768797.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -29,7 +30,7 @@
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":10.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":9.0,
     "name:ben_x_preferred":[
         "\u09b9\u09c7\u09b0\u09c7\u09a6\u09bf\u09df\u09be"
@@ -129,14 +130,16 @@
         }
     ],
     "wof:id":1276768797,
-    "wof:lastmodified":1636505079,
+    "wof:lastmodified":1705624225,
     "wof:name":"Heredia",
     "wof:parent_id":421183455,
     "wof:placetype":"locality",
     "wof:population":21947,
     "wof:population_rank":7,
     "wof:repo":"whosonfirst-data-admin-cr",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421170397
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/421/166/603/421166603.geojson
+++ b/data/421/166/603/421166603.geojson
@@ -9,8 +9,11 @@
     "geom:bbox":"-84.05074,9.92829,-84.05074,9.92829",
     "geom:latitude":9.92829,
     "geom:longitude":-84.05074,
+    "gn:country":null,
     "iso:country":"CR",
     "lbl:bbox":"-84.15074,9.82829,-83.95074,10.02829",
+    "lbl:latitude":9.92829,
+    "lbl:longitude":-84.05074,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
@@ -122,6 +125,9 @@
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043d-\u041f\u0435\u0434\u0440\u043e"
     ],
+    "name:und_x_variant":[
+        "Pedro"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u0627\u0646 \u067e\u06cc\u0688\u0631\u0648"
     ],
@@ -155,7 +161,30 @@
     "qs:qs_id":267801,
     "qs:woe_adm0":23424791,
     "qs:woe_id":26809230,
+    "qs_pg:aaroncc":"CR",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"San Pedro",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"Alajuela",
+    "qs_pg:photos":2,
+    "qs_pg:photos_1k":1,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":1,
+    "qs_pg:photos_all":2,
+    "qs_pg:photos_sr":1,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":1017246,
+    "qs_pg:qs_pg_placetype":"localadmin",
+    "qs_pg:qs_pg_placetype_gp":"LocalAdmin",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":26809228,
     "src:geom":"quattroshapes",
+    "src:lbl_centroid":"qs_pg",
+    "src:population":"quattroshapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"Alajuela",
+    "woe:placetype":"LocalAdmin",
     "wof:belongsto":[
         102191575,
         85632487,
@@ -164,8 +193,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "gn:id":3621717,
         "gp:id":26809230,
         "qs_pg:id":267801
+    },
+    "wof:concordances_alt":{
+        "gp:id":26809228,
+        "qs_pg:id":1017246
     },
     "wof:country":"CR",
     "wof:created":1459008696,
@@ -180,13 +214,20 @@
         }
     ],
     "wof:id":421166603,
-    "wof:lastmodified":1636505100,
+    "wof:lastmodified":1705624223,
     "wof:name":"San Pedro",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",
+    "wof:population":27477,
+    "wof:population_rank":7,
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        421173725,
+        421185049,
+        421185053,
+        1125389441
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/421/170/397/421170397.geojson
+++ b/data/421/170/397/421170397.geojson
@@ -9,6 +9,21 @@
     "geom:bbox":"-84.11651,10.00236,-84.11651,10.00236",
     "geom:latitude":10.00236,
     "geom:longitude":-84.11651,
+    "gn:admin1_code":"04",
+    "gn:admin2_code":"401",
+    "gn:admin3_code":"40101.0",
+    "gn:asciiname":"Heredia",
+    "gn:country_code":"CR",
+    "gn:dem":1174,
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPLA",
+    "gn:geonameid":3623486,
+    "gn:latitude":10.00236,
+    "gn:longitude":-84.11651,
+    "gn:modification_date":"2016-09-07",
+    "gn:name":"Heredia",
+    "gn:population":21947,
+    "gn:timezone":"America/Costa_Rica",
     "iso:country":"CR",
     "lbl:bbox":"-84.13651,9.98236,-84.09651,10.02236",
     "lbl:max_zoom":14.0,
@@ -127,6 +142,9 @@
         "Heredia"
     ],
     "name:nah_x_preferred":[
+        "Heredia"
+    ],
+    "name:nds_x_preferred":[
         "Heredia"
     ],
     "name:nld_x_preferred":[
@@ -346,7 +364,9 @@
         "wk:page":"Heredia, Costa Rica"
     },
     "wof:concordances_alt":{
-        "qs_pg:id":1200232
+        "gn:id":3623486,
+        "qs_pg:id":1200232,
+        "wk:page":"Heredia"
     },
     "wof:country":"CR",
     "wof:created":1459008851,
@@ -364,7 +384,7 @@
         }
     ],
     "wof:id":421170397,
-    "wof:lastmodified":1690868478,
+    "wof:lastmodified":1705624225,
     "wof:name":"Heredia",
     "wof:parent_id":421183455,
     "wof:placetype":"locality",
@@ -372,7 +392,9 @@
     "wof:population_rank":7,
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1276768797
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/421/173/725/421173725.geojson
+++ b/data/421/173/725/421173725.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -14,7 +15,7 @@
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":10.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:arg_x_preferred":[
@@ -185,14 +186,16 @@
         }
     ],
     "wof:id":421173725,
-    "wof:lastmodified":1636505107,
+    "wof:lastmodified":1705624222,
     "wof:name":"San Pedro",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",
     "wof:population":27477,
     "wof:population_rank":7,
     "wof:repo":"whosonfirst-data-admin-cr",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421166603
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/421/185/049/421185049.geojson
+++ b/data/421/185/049/421185049.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -14,7 +15,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:arg_x_preferred":[
@@ -180,12 +181,14 @@
         }
     ],
     "wof:id":421185049,
-    "wof:lastmodified":1636505117,
+    "wof:lastmodified":1705624223,
     "wof:name":"San Pedro",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-cr",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421166603
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/421/185/053/421185053.geojson
+++ b/data/421/185/053/421185053.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -14,7 +15,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:arg_x_preferred":[
@@ -186,12 +187,14 @@
         }
     ],
     "wof:id":421185053,
-    "wof:lastmodified":1636505117,
+    "wof:lastmodified":1705624223,
     "wof:name":"San Pedro",
     "wof:parent_id":421169975,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-cr",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421166603
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/857/657/55/85765755.geojson
+++ b/data/857/657/55/85765755.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.051026,9.905574,-84.051026,9.905574",
     "geom:latitude":9.905574,
     "geom:longitude":-84.051026,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.056026,9.900574,-84.046026,9.910574",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Arpaza"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26809170,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Arpaza",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":142,
+    "qs_pg:photos_1k":29,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":3,
+    "qs_pg:photos_all":142,
+    "qs_pg:photos_sr":3,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":230469,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723596,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723596,
         "qs_pg:id":230469
     },
+    "wof:concordances_alt":{
+        "gp:id":22723596,
+        "qs_pg:id":230469
+    },
     "wof:country":"CR",
+    "wof:created":1497315208,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624223,
     "wof:name":"Arpaza",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126095947
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/657/65/85765765.geojson
+++ b/data/857/657/65/85765765.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.049244,9.933202,-84.049244,9.933202",
     "geom:latitude":9.933202,
     "geom:longitude":-84.049244,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.054244,9.928202,-84.044244,9.938202",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:ita_x_preferred":[
         "Zapote"
@@ -63,11 +65,31 @@
     "qs:woe_lau":26809330,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Yoses Sur",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":1807,
+    "qs_pg:photos_1k":366,
+    "qs_pg:photos_9k":8,
+    "qs_pg:photos_9r":9,
+    "qs_pg:photos_all":1807,
+    "qs_pg:photos_sr":14,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":224732,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723659,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -79,7 +101,12 @@
         "gp:id":22723659,
         "qs_pg:id":224732
     },
+    "wof:concordances_alt":{
+        "gp:id":22723659,
+        "qs_pg:id":224732
+    },
     "wof:country":"CR",
+    "wof:created":1497314585,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -98,13 +125,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624223,
     "wof:name":"Yoses Sur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126093485
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/657/69/85765769.geojson
+++ b/data/857/657/69/85765769.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.074518,9.923819,-84.074518,9.923819",
     "geom:latitude":9.923819,
     "geom:longitude":-84.074518,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.079518,9.918819,-84.069518,9.928819",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Ujarraz"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26809330,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Ujarraz",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":72,
+    "qs_pg:photos_1k":15,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":2,
+    "qs_pg:photos_all":72,
+    "qs_pg:photos_sr":2,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":896299,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723662,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723662,
         "qs_pg:id":896299
     },
+    "wof:concordances_alt":{
+        "gp:id":22723662,
+        "qs_pg:id":896299
+    },
     "wof:country":"CR",
+    "wof:created":1497312503,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624223,
     "wof:name":"Ujarraz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126084379
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/657/71/85765771.geojson
+++ b/data/857/657/71/85765771.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.065881,9.937376,-84.065881,9.937376",
     "geom:latitude":9.937376,
     "geom:longitude":-84.065881,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.070881,9.932376,-84.060881,9.942376",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Seguro Social"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26808924,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Seguro Social",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":932,
+    "qs_pg:photos_1k":189,
+    "qs_pg:photos_9k":4,
+    "qs_pg:photos_9r":6,
+    "qs_pg:photos_all":932,
+    "qs_pg:photos_sr":10,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":896294,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723685,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723685,
         "qs_pg:id":896294
     },
+    "wof:concordances_alt":{
+        "gp:id":22723685,
+        "qs_pg:id":896294
+    },
     "wof:country":"CR",
+    "wof:created":1497313289,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624223,
     "wof:name":"Seguro Social",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126088885
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/657/75/85765775.geojson
+++ b/data/857/657/75/85765775.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.072746,9.931732,-84.072746,9.931732",
     "geom:latitude":9.931732,
     "geom:longitude":-84.072746,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.077746,9.926732,-84.067746,9.936732",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:ara_x_preferred":[
         "\u0633\u0648\u0644\u064a\u062f\u0627\u062f"
@@ -122,11 +124,31 @@
     "qs:woe_lau":26808932,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Soledad",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":633,
+    "qs_pg:photos_1k":128,
+    "qs_pg:photos_9k":3,
+    "qs_pg:photos_9r":5,
+    "qs_pg:photos_all":633,
+    "qs_pg:photos_sr":8,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":346804,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723689,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -138,7 +160,12 @@
         "gp:id":22723689,
         "qs_pg:id":346804
     },
+    "wof:concordances_alt":{
+        "gp:id":22723689,
+        "qs_pg:id":346804
+    },
     "wof:country":"CR",
+    "wof:created":1497313341,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -157,13 +184,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1636505065,
+    "wof:lastmodified":1705624223,
     "wof:name":"Soledad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126089075
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/657/81/85765781.geojson
+++ b/data/857/657/81/85765781.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.081206,9.930219,-84.081206,9.930219",
     "geom:latitude":9.930219,
     "geom:longitude":-84.081206,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.086206,9.925219,-84.076206,9.935219",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Dolorosa"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26808932,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Dolorosa",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":3964,
+    "qs_pg:photos_1k":803,
+    "qs_pg:photos_9k":18,
+    "qs_pg:photos_9r":12,
+    "qs_pg:photos_all":3964,
+    "qs_pg:photos_sr":22,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":889892,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723690,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723690,
         "qs_pg:id":889892
     },
+    "wof:concordances_alt":{
+        "gp:id":22723690,
+        "qs_pg:id":889892
+    },
     "wof:country":"CR",
+    "wof:created":1497312322,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624223,
     "wof:name":"Dolorosa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126083471
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/657/89/85765789.geojson
+++ b/data/857/657/89/85765789.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.086204,9.936217,-84.086204,9.936217",
     "geom:latitude":9.936217,
     "geom:longitude":-84.086204,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.091204,9.931217,-84.081204,9.941217",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:afr_x_preferred":[
         "Coca-Cola"
@@ -378,12 +380,32 @@
     "qs:woe_lau":26808932,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Coca Cola",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":627,
+    "qs_pg:photos_1k":127,
+    "qs_pg:photos_9k":3,
+    "qs_pg:photos_9r":5,
+    "qs_pg:photos_all":627,
+    "qs_pg:photos_sr":8,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":889894,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723695,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":10075,
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -395,7 +417,12 @@
         "gp:id":22723695,
         "qs_pg:id":889894
     },
+    "wof:concordances_alt":{
+        "gp:id":22723695,
+        "qs_pg:id":889894
+    },
     "wof:country":"CR",
+    "wof:created":1497312322,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -414,13 +441,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Coca Cola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126083475
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/07/85765807.geojson
+++ b/data/857/658/07/85765807.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.075412,9.937796,-84.075412,9.937796",
     "geom:latitude":9.937796,
     "geom:longitude":-84.075412,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.080412,9.932796,-84.070412,9.942796",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:bre_x_preferred":[
         "Tournon"
@@ -77,12 +79,32 @@
     "qs:woe_lau":26808924,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Tournon",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":1204,
+    "qs_pg:photos_1k":244,
+    "qs_pg:photos_9k":5,
+    "qs_pg:photos_9r":7,
+    "qs_pg:photos_all":1204,
+    "qs_pg:photos_sr":11,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":1196558,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723707,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":51,
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -94,7 +116,12 @@
         "gp:id":22723707,
         "qs_pg:id":1196558
     },
+    "wof:concordances_alt":{
+        "gp:id":22723707,
+        "qs_pg:id":1196558
+    },
     "wof:country":"CR",
+    "wof:created":1497316761,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -113,13 +140,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Tournon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126105041
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/13/85765813.geojson
+++ b/data/857/658/13/85765813.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.138892,9.956891,-84.138892,9.956891",
     "geom:latitude":9.956891,
     "geom:longitude":-84.138892,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.143892,9.951891,-84.133892,9.961891",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:cat_x_preferred":[
         "Santa Catalina"
@@ -108,11 +110,31 @@
     "qs:woe_lau":26809096,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Santa Catalina",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":180,
+    "qs_pg:photos_1k":36,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":4,
+    "qs_pg:photos_all":180,
+    "qs_pg:photos_sr":4,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":946555,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723790,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -124,7 +146,12 @@
         "gp:id":22723790,
         "qs_pg:id":946555
     },
+    "wof:concordances_alt":{
+        "gp:id":22723790,
+        "qs_pg:id":946555
+    },
     "wof:country":"CR",
+    "wof:created":1497308492,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -143,13 +170,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Santa Catalina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126063675
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/19/85765819.geojson
+++ b/data/857/658/19/85765819.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.09384,9.973977,-84.09384,9.973977",
     "geom:latitude":9.973977,
     "geom:longitude":-84.09384,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.09884,9.968977,-84.08884,9.978977",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Virilla"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26809317,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Virilla",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":276,
+    "qs_pg:photos_1k":56,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":4,
+    "qs_pg:photos_all":276,
+    "qs_pg:photos_sr":5,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":237727,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723800,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670375,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723800,
         "qs_pg:id":237727
     },
+    "wof:concordances_alt":{
+        "gp:id":22723800,
+        "qs_pg:id":237727
+    },
     "wof:country":"CR",
+    "wof:created":1497316001,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Virilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126100811
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/23/85765823.geojson
+++ b/data/857/658/23/85765823.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.101909,9.936889,-84.101909,9.936889",
     "geom:latitude":9.936889,
     "geom:longitude":-84.101909,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.106909,9.931889,-84.096909,9.941889",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:ace_x_preferred":[
         "Amirika"
@@ -657,12 +659,32 @@
     "qs:woe_lau":26809056,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Americas",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":276,
+    "qs_pg:photos_1k":56,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":4,
+    "qs_pg:photos_all":276,
+    "qs_pg:photos_sr":5,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":237728,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723811,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":8517,
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -674,7 +696,12 @@
         "gp:id":22723811,
         "qs_pg:id":237728
     },
+    "wof:concordances_alt":{
+        "gp:id":22723811,
+        "qs_pg:id":237728
+    },
     "wof:country":"CR",
+    "wof:created":1497316001,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -693,13 +720,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Americas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126100819
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/35/85765835.geojson
+++ b/data/857/658/35/85765835.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.12296,9.942499,-84.12296,9.942499",
     "geom:latitude":9.942499,
     "geom:longitude":-84.12296,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.12796,9.937499,-84.11796,9.947499",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":16.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Favorita Sur"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26809096,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Favorita Sur",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":48,
+    "qs_pg:photos_1k":10,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":2,
+    "qs_pg:photos_all":48,
+    "qs_pg:photos_sr":2,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":986128,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723818,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723818,
         "qs_pg:id":986128
     },
+    "wof:concordances_alt":{
+        "gp:id":22723818,
+        "qs_pg:id":986128
+    },
     "wof:country":"CR",
+    "wof:created":1497309681,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Favorita Sur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126069807
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/43/85765843.geojson
+++ b/data/857/658/43/85765843.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.103714,9.934283,-84.103714,9.934283",
     "geom:latitude":9.934283,
     "geom:longitude":-84.103714,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.108714,9.929283,-84.098714,9.939283",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":16.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:cat_x_preferred":[
         "Nossa Senhora do Perp\u00e9tuo Socorro"
@@ -66,11 +68,31 @@
     "qs:woe_lau":26809014,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Perpetuo Socorro",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":96,
+    "qs_pg:photos_1k":19,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":3,
+    "qs_pg:photos_all":96,
+    "qs_pg:photos_sr":3,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":1000754,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723835,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -82,7 +104,12 @@
         "gp:id":22723835,
         "qs_pg:id":1000754
     },
+    "wof:concordances_alt":{
+        "gp:id":22723835,
+        "qs_pg:id":1000754
+    },
     "wof:country":"CR",
+    "wof:created":1497311191,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -101,13 +128,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Perpetuo Socorro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126076723
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/47/85765847.geojson
+++ b/data/857/658/47/85765847.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.101204,9.930812,-84.101204,9.930812",
     "geom:latitude":9.930812,
     "geom:longitude":-84.101204,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.106204,9.925812,-84.096204,9.935812",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Paseo Colon"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26809014,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Paseo Colon",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":287,
+    "qs_pg:photos_1k":58,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":4,
+    "qs_pg:photos_all":287,
+    "qs_pg:photos_sr":5,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":366561,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723837,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723837,
         "qs_pg:id":366561
     },
+    "wof:concordances_alt":{
+        "gp:id":22723837,
+        "qs_pg:id":366561
+    },
     "wof:country":"CR",
+    "wof:created":1497313552,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Paseo Colon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126089941
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/49/85765849.geojson
+++ b/data/857/658/49/85765849.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.098547,9.935469,-84.098547,9.935469",
     "geom:latitude":9.935469,
     "geom:longitude":-84.098547,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.103547,9.930469,-84.093547,9.940469",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:nld_x_preferred":[
         "Mantica horni"
@@ -56,12 +58,32 @@
     "qs:woe_lau":26809014,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Mantica",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":259,
+    "qs_pg:photos_1k":52,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":4,
+    "qs_pg:photos_all":259,
+    "qs_pg:photos_sr":5,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":1087512,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723838,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":30,
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -73,7 +95,12 @@
         "gp:id":22723838,
         "qs_pg:id":1087512
     },
+    "wof:concordances_alt":{
+        "gp:id":22723838,
+        "qs_pg:id":1087512
+    },
     "wof:country":"CR",
+    "wof:created":1497314099,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -92,13 +119,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Mantica",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126092097
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/658/63/85765863.geojson
+++ b/data/857/658/63/85765863.geojson
@@ -9,6 +9,7 @@
     "geom:bbox":"-84.103088,9.914563,-84.103088,9.914563",
     "geom:latitude":9.914563,
     "geom:longitude":-84.103088,
+    "gn:country":null,
     "gn:id":"",
     "iso:country":"CR",
     "lbl:bbox":"-84.108088,9.909563,-84.098088,9.919563",
@@ -25,6 +26,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":16.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":3,
     "name:spa_x_preferred":[
         "Hatillo No.3"
@@ -53,11 +55,31 @@
     "qs:woe_lau":26809010,
     "qs:woe_local":59426,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:gn_country":null,
+    "qs_pg:name":"Hatillo No.3",
+    "qs_pg:name_adm0":"Costa Rica",
+    "qs_pg:name_adm1":"San Jose",
+    "qs_pg:photos":19,
+    "qs_pg:photos_1k":4,
+    "qs_pg:photos_9k":1,
+    "qs_pg:photos_9r":1,
+    "qs_pg:photos_all":19,
+    "qs_pg:photos_sr":1,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":264773,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424791,
+    "qs_pg:woe_id":22723860,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424791,
+    "woe:name_adm0":"Costa Rica",
+    "woe:name_adm1":"San Jose",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85670391,
         102191575,
@@ -69,7 +91,12 @@
         "gp:id":22723860,
         "qs_pg:id":264773
     },
+    "wof:concordances_alt":{
+        "gp:id":22723860,
+        "qs_pg:id":264773
+    },
     "wof:country":"CR",
+    "wof:created":1497316885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
@@ -88,13 +115,15 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582381931,
+    "wof:lastmodified":1705624224,
     "wof:name":"Hatillo No.3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-cr",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126105705
+    ],
     "wof:tags":[]
 },
   "bbox": [


### PR DESCRIPTION
This PR updates duplicate records within WOF. When a duplicate pair/set is found:

- One record is superseded into the other
- Properties are transferred from the superseded record to the superseding record (if the property doesn't already exist)
- Concordances are transferred from the superseded record to the superseding record. If the concordance exists, a `wof:concordances_alt` property is used. If the concordance doesn't exist, it's added to the `wof:concordances` property

Duplicates were found by scoping a single placetype, checking for records with geometries near one another and identical (or nearly identical) names. Duplicate pairs were found the following way:

- If two point geometries: within 300m of one another
  - The older record of the two is kept, the newest is superseded
- If one point and one polygon: point is within the polygon OR point is within 300m of the polygon record's centroid
  - The record with the polygon is kept, the point is superseded
- If two polygon geometries: polygons overlap OR both records' centroids are within 300m of one another
  - The older record of the two is kept, the newest is superseded

Because this work is not scoped to a single repo, this work will also catch (many) cases where duplicates exist across two or more repos (one record in `whosonfirst-data-admin-xx` and `whosonfirst-data-admin-cr`, for example). I'm sure there are some edge cases that won't be caught with these parameters, but the duplicates I've reviewed have been legitimate. No PIP work needed - once this is approved, I'll open a few more PRs for review before running against all admin repos.